### PR TITLE
v.1.0.2 of coq-min-imports package

### DIFF
--- a/released/packages/coq-min-imports/coq-min-imports.1.0.2/descr
+++ b/released/packages/coq-min-imports/coq-min-imports.1.0.2/descr
@@ -1,0 +1,4 @@
+This script will try to remove unnecessary module imports from Coq
+sources. It examines modules listed in "Require Import" statements one
+by one and tries to recompile to see if their removal would cause
+compilation errors.

--- a/released/packages/coq-min-imports/coq-min-imports.1.0.2/opam
+++ b/released/packages/coq-min-imports/coq-min-imports.1.0.2/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+version: "1.0.2"
+maintainer: "lord@crocodile.org"
+homepage: "https://github.com/vzaliva/coq-min-imports"
+dev-repo: "https://github.com/vzaliva/coq-min-imports.git"
+bug-reports: "https://github.com/vzaliva/coq-min-imports/issues"
+authors: ["Vadim Zaliva"]
+license: "MIT"
+build: ["jbuilder" "build" "-j" jobs "@install"]
+
+depends: [
+  "coq" {>= "8.5"}
+  "extlib"
+  "batteries"
+  "jbuilder" {build}
+]
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "date:2018-04-22"
+]

--- a/released/packages/coq-min-imports/coq-min-imports.1.0.2/url
+++ b/released/packages/coq-min-imports/coq-min-imports.1.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/vzaliva/coq-min-imports/archive/v1.0.2.tar.gz"
+checksum: "1df90607ac535f3e2ffe008e3561333b"


### PR DESCRIPTION
renamed binary to `coq-min-imports` and fixes installation problem under OPAM