### PR TITLE
coq-fcsl-pcm is compatible with Mathcomp 1.11

### DIFF
--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.2.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.2.0/opam
@@ -9,9 +9,8 @@ license: "Apache-2.0"
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "ocaml"
   "coq" {(>= "8.10" & < "8.12~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.10.0" & < "1.11~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.10.0" & < "1.12~") | (= "dev")}
 ]
 tags: [
   "keyword:separation logic"


### PR DESCRIPTION
I have forgotten why `"ocaml"` constraint was there, so I removed it. It is some sort of workaround?