### PR TITLE
Add coq-paramcoq.1.1.3+coq8.{10,11,12}

### DIFF
--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.10/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "git+https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.10" & < "8.11~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:OCaml modules"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+  "date:2021-09-24"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]
+synopsis: "Plugin for generating parametricity statements to perform refinement proofs"
+description: """
+A Coq plugin providing commands for generating parametricity statements.
+Typical applications of such statements are in data refinement proofs.
+Note that the plugin is still in an experimental state - it is not very user
+friendly (lack of good error messages) and still contains bugs. But it
+is usable enough to "translate" a large chunk of the standard library."""
+url {
+  src: "https://github.com/coq-community/paramcoq/archive/v1.1.3+coq8.10.tar.gz"
+  checksum: "sha512=7e1c8cb69a70d2ee900171e416cc20a4249ced681cae5d144001b0ba938b5d4bc841ca768c045a5ab1dcb42145a090f2339fafb1c49f999875a0b3891f67e328"
+}

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.11/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.11/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "git+https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.11" & < "8.12~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:OCaml modules"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+  "date:2021-09-24"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]
+synopsis: "Plugin for generating parametricity statements to perform refinement proofs"
+description: """
+A Coq plugin providing commands for generating parametricity statements.
+Typical applications of such statements are in data refinement proofs.
+Note that the plugin is still in an experimental state - it is not very user
+friendly (lack of good error messages) and still contains bugs. But it
+is usable enough to "translate" a large chunk of the standard library."""
+url {
+  src: "https://github.com/coq-community/paramcoq/archive/v1.1.3+coq8.11.tar.gz"
+  checksum: "sha512=c2d4edf652dd6bea4b790d78ccfc8a560822e1db9033e9df36cfd481f7289ac41328e2d4ea662dc9af6c2c92ad5d3804edff8fb87873af371a638539be957b31"
+}

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.12/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.3+coq8.12/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "git+https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.12" & < "8.13~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:OCaml modules"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+  "date:2021-09-24"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]
+synopsis: "Plugin for generating parametricity statements to perform refinement proofs"
+description: """
+A Coq plugin providing commands for generating parametricity statements.
+Typical applications of such statements are in data refinement proofs.
+Note that the plugin is still in an experimental state - it is not very user
+friendly (lack of good error messages) and still contains bugs. But it
+is usable enough to "translate" a large chunk of the standard library."""
+url {
+  src: "https://github.com/coq-community/paramcoq/archive/v1.1.3+coq8.12.tar.gz"
+  checksum: "sha512=f3bbfa2b2f064e9c675aafa6c3b2c7666c709d5586448e79caab1c45a4bdd588bc6b7cdfcfc32a9bd9250f7278689ceaaf4c6e5ad5b45ba8bd9bd45d89af0508"
+}


### PR DESCRIPTION
To keep CoqEAL compatible with Coq 8.10: https://github.com/coq-community/coqeal/pull/52