### PR TITLE
coq-compcert.3.9: allow Coq 8.14

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.9/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.9/opam
@@ -29,7 +29,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.9.0" & < "8.14"}
+  "coq" {>= "8.9.0" & < "8.15~"}
   "menhir" {>= "20190626" }
   "ocaml" {>= "4.05.0"}
   "coq-flocq" {>= "3.1.0"}

--- a/released/packages/coq-compcert/coq-compcert.3.9/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.9/opam
@@ -28,7 +28,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.9.0" & < "8.14"}
+  "coq" {>= "8.9.0" & < "8.15~"}
   "menhir" {>= "20190626" }
   "ocaml" {>= "4.05.0"}
   "coq-flocq" {>= "3.1.0"}


### PR DESCRIPTION
This PR enables Coq 8.14 in the latest Compcert opam packages.

This change is agreed on with @xavierleroy here (https://github.com/AbsInt/CompCert/issues/414)