### PR TITLE
coq-mathcomp-analysis: allow Coq 8.14

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
@@ -14,7 +14,7 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.11" & < "8.14~") | (= "dev") }
+  "coq" { (>= "8.11" & < "8.15~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-fingroup" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") | (= "dev") }


### PR DESCRIPTION
This PR enables Coq 8.14 for coq-mathcomp-analysis