### PR TITLE
coq-stdpp: fix Windows build

### DIFF
--- a/released/packages/coq-stdpp/coq-stdpp.1.5.0/files/0001-Windows-CI-strip-CR-in-result-comparison.patch
+++ b/released/packages/coq-stdpp/coq-stdpp.1.5.0/files/0001-Windows-CI-strip-CR-in-result-comparison.patch
@@ -1,0 +1,24 @@
+From 132faca188fbee3c3b508ebe45357274aac8026d Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 26 Sep 2021 09:32:32 +0200
+Subject: [PATCH] Windows CI: strip CR in result comparison
+
+---
+ Makefile.coq.local | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.coq.local b/Makefile.coq.local
+index 9dc1159..91660ce 100644
+--- a/Makefile.coq.local
++++ b/Makefile.coq.local
+@@ -45,6 +45,6 @@ $(TESTFILES:.v=.vo): %.vo: %.v $(if $(MAKE_REF),,%.ref) $(NORMALIZER)
+ 	  $(TIMER) $(COQ_TEST) $(COQFLAGS) $(COQLIBS) -load-vernac-source $< > "$$TMPFILE" && \
+ 	  sed -f $(NORMALIZER) "$$TMPFILE" > "$$TMPFILE".new && \
+ 	  mv "$$TMPFILE".new "$$TMPFILE" && \
+-	  $(if $(MAKE_REF),mv "$$TMPFILE" "$$REF",diff -u "$$REF" "$$TMPFILE") && \
++	  $(if $(MAKE_REF),mv "$$TMPFILE" "$$REF",diff --strip-trailing-cr -u "$$REF" "$$TMPFILE") && \
+ 	  rm -f "$$TMPFILE" && \
+ 	  touch $@
+-- 
+2.33.0
+

--- a/released/packages/coq-stdpp/coq-stdpp.1.5.0/opam
+++ b/released/packages/coq-stdpp/coq-stdpp.1.5.0/opam
@@ -35,7 +35,7 @@ tags: [
 depends: [
   "coq" { (>= "8.10.2" & < "8.14~") | (= "dev") }
 ]
-
+patches: [ "0001-Windows-CI-strip-CR-in-result-comparison.patch" ]
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 


### PR DESCRIPTION
This PR fixes the build of coq-stdpp on Windows.
