### PR TITLE
coq-hott: added opam package for version 8.14

### DIFF
--- a/released/packages/coq-hott/coq-hott.8.14/opam
+++ b/released/packages/coq-hott/coq-hott.8.14/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.13" & < "8.15~"}
+  "coq" {>= "8.14" & < "8.15~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"


### PR DESCRIPTION
This PR adds an opam package for the new version 8.14 of coq-hott.

FYI: @Alizter