### PR TITLE
coq-bignums.8.14.0 only works with OCaml before 4.13

### DIFF
--- a/released/packages/coq-bignums/coq-bignums.8.14.0/opam
+++ b/released/packages/coq-bignums/coq-bignums.8.14.0/opam
@@ -15,7 +15,7 @@ build: [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
 install: [make "install"]
 
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.05" & < "4.13"}
   "coq" {>= "8.14" & < "8.15~"}
 ]
 


### PR DESCRIPTION
To partially address coq/bignums#62

cc: @MSoegtropIMC 