### PR TITLE
add coq.8.16+rc1

### DIFF
--- a/core-dev/packages/coq/coq.8.16+rc1/opam
+++ b/core-dev/packages/coq/coq.8.16+rc1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1-only"
+synopsis: "Formal proof management system"
+description: """
+The Coq proof assistant provides a formal language to write
+mathematical definitions, executable algorithms, and theorems, together
+with an environment for semi-interactive development of machine-checked
+proofs. Typical applications include the certification of properties of programming
+languages (e.g., the CompCert compiler certification project and the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g., the full formalization of the Feit-Thompson theorem
+and homotopy type theory) and teaching.
+"""
+
+depopts: [
+  "coq-native"
+]
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "ocamlfind" {>= "1.8.1" & build}
+  "dune" {>= "2.5.1"}
+  "conf-findutils" {build}
+  "zarith" {>= "1.11"}
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" "%{doc}%/coq"
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [ make "COQ_USE_DUNE=" "-j%{jobs}%" ]
+]
+install: [
+  [ make "COQ_USE_DUNE=" "install" ]
+]
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.16+rc1.tar.gz"
+  checksum: "sha512=87ad8e9975e0a0e79582d28e3e1e050f3ab4dbeb020b2181ca48a3d01b59061f2fcb2c09c76539b15a62288f2ad1958de8b7ea9be8ba374e58071fbc9edff875"
+}


### PR DESCRIPTION
This is based on extrapolation from the current `8.15.1` opam package and the new constraints in opam files in the tag.