### PR TITLE
Remove dune & opam project files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,0 @@
-(lang dune 1.9)
-(name opam-coq-archive)


### PR DESCRIPTION
These files seem dummy. They were introduced with the initial build of the json data producing tool for the Coq Package Index.