### PR TITLE
Package coq-waterproof.2.0.1+8.17

### DIFF
--- a/released/packages/coq-waterproof/coq-waterproof.2.0.1+8.17/opam
+++ b/released/packages/coq-waterproof/coq-waterproof.2.0.1+8.17/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "coq-waterproof"
-version: "2.0.1+8.17"
 maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
 authors: [
   "Jelle Wemmenhove"

--- a/released/packages/coq-waterproof/coq-waterproof.2.0.1+8.17/opam
+++ b/released/packages/coq-waterproof/coq-waterproof.2.0.1+8.17/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+name: "coq-waterproof"
+version: "2.0.1+8.17"
+maintainer: "Jim Portegies <j.w.portegies@tue.nl>"
+authors: [
+  "Jelle Wemmenhove"
+  "Balthazar Pathiachvili"
+  "Cosmin Manea"
+  "Lulof Pirée"
+  "Adrian Vrămuleţ"
+  "Tudor Voicu"
+  "Jim Portegies <j.w.portegies@tue.nl>"
+]
+
+synopsis: "Coq proofs in a style that resembles non-mechanized mathematical proofs"
+description: """
+The coq-waterproof library allows you to write Coq proofs in a style that resembles non-mechanized mathematical proofs.
+Mathematicians unfamiliar with the Coq syntax are able to read the resulting proof scripts.
+"""
+
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/impermeable/coq-waterproof"
+dev-repo: "git+https://github.com/impermeable/coq-waterproof.git"
+bug-reports: "https://github.com/impermeable/coq-waterproof/issues"
+
+depends: [
+  "ocaml" {>= "4.14.1"}
+  "coq" {>= "8.17" & < "8.18"}
+]
+
+build: [
+  ["dune" "build" "-p" "coq-waterproof"]
+]
+
+install: [
+  ["dune" "install" "-p" "coq-waterproof"]
+]
+
+url {
+  src:
+    "https://github.com/impermeable/coq-waterproof/archive/refs/tags/2.0.1+8.17.tar.gz"
+  checksum: [
+    "md5=a891f29ee1723d8031d4cb50903da735"
+    "sha512=cfc7a8010b71ab45264f396b144f0cf887baf9ddae9df1e92d977252801197017225af0d4bbabaf7a0b57454aa2ce68989c58ce6c1707b4bc40674488bf0a622"
+  ]
+}
+
+tags: [
+  "keyword:mathematics education"
+  "category:Mathematics/Education"
+  "date:2023-08-27"
+  "logpath:Waterproof"
+]


### PR DESCRIPTION
We would like to submit a new version of coq-waterproof. The main change from the previous version is that we the library is converted to a plugin. It may be that we still need a review of the ml code by a Coq developer.