### PR TITLE
Add vcfloat.2.1.1 release to opam-coq-archive

### DIFF
--- a/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
+++ b/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "VCFloat: Floating Point Round-off Error Analysis"
+description: "VCFloat is a tool for Coq proofs about floating-point round-off error."
+authors: [
+  "Andrew W. Appel"
+  "Ariel E. Kellison"
+  "Tahina Ramananandro"
+  "Paul Mountcastle"
+  "Benoit Meister"
+  "Richard Lethin"
+]
+homepage: "https://verinum.org/vcfloat/"
+maintainer: "Andrew W. Appel <appel@princeton.edu>"
+dev-repo: "git+https://github.com/VeriNum/vcfloat"
+bug-reports: "https://github.com/VeriNum/vcfloat/issues"
+license: "LGPL-3.0-or-later"
+
+build: [
+  [ make "-C" "vcfloat" "-j%{jobs}%" "vcfloat2"]
+]
+install: [
+  [make "-C" "vcfloat" "-j%{jobs}%" "install" "INSTALLDIR=%{lib}%/coq/user-contrib/vcfloat"]
+]
+run-test: [
+  [make "-C" "vcfloat" "-j%{jobs}%" "tests"]
+]
+depends: [
+  "coq" {>= "8.16" & < "8.18~"}
+  "coq-flocq" {>= "4.1.1" & < "5.0"}
+  "coq-interval" {>= "4.8.0"}
+  "coq-compcert" {>= "3.12"}
+  "coq-bignums"
+]
+url {
+  src: "https://github.com/VeriNum/vcfloat/archive/refs/tags/2.1.1.tar.gz"
+  checksum: "sha256=cd0098a7448e13116f4bb1faa3d93c6f1a8b5a6fa83be979875b432aeb9eb27e"
+}
+tags: [
+  "date:2023-08-31"
+  "keyword:decision procedure"
+  "keyword:floating-point arithmetic"
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "logpath:VCFloat"
+  ]

--- a/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
+++ b/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
@@ -32,7 +32,7 @@ depends: [
   "coq-bignums"
 ]
 url {
-  src: "https://github.com/VeriNum/vcfloat/archive/refs/tags/2.1.1.tar.gz"
+  src: "https://github.com/VeriNum/vcfloat/archive/refs/tags/v2.1.1.tar.gz"
   checksum: "sha256=cd0098a7448e13116f4bb1faa3d93c6f1a8b5a6fa83be979875b432aeb9eb27e"
 }
 tags: [


### PR DESCRIPTION
This release of vcfloat 2.1 has very minor changes for compatibility with the Flocq.4.1.1 in the Coq Platform 2023.03 release.