### PR TITLE
coq-flocq.4.1.1 not compatible with 8.18

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.4.1.1/opam
+++ b/released/packages/coq-flocq/coq-flocq.4.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.12"}
+  "coq" {>= "8.12" & < "8.18"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]


### PR DESCRIPTION
cc: @silene 

Here is the error I get with Coq 8.18+rc1, which probably needs a new release to fix:
```
# File "./src/Pff/Pff2Flocq.v", line 902, characters 34-42:
# Error: The variable div_Zdiv was not found in the current environment.
```
