### PR TITLE
coq-mathcomp-real-closed.1.1.4 supports 8.18

### DIFF
--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.4/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.4/opam
@@ -14,11 +14,11 @@ closure (including a proof of the fundamental theorem of
 algebra). It also contains a proof of decidability of the first
 order theory of real closed field, through quantifier elimination."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.13" & < "8.18~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.13.0" & < "1.18~") | (= "dev")  }
+  "coq" {>= "8.13" & < "8.19~"}
+  "coq-mathcomp-ssreflect" {>= "1.13.0" & < "1.18~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-field"
   "coq-mathcomp-bigenough" {>= "1.0.0"}


### PR DESCRIPTION
Tested locally.

cc: @CohenCyril 