### PR TITLE
coq-mathcomp-algebra-tactics.1.1.1 works on Coq 8.18

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.1/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.1/opam
@@ -21,7 +21,7 @@ ring/field expressions before applying the proof procedures."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.18~"}
+  "coq" {>= "8.16" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.15" & < "1.18~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.1.0"}


### PR DESCRIPTION
Tested locally with 8.18+rc1.

cc: @proux01 @pi8027 