### PR TITLE
Upper MathComp bounds for some packages

### DIFF
--- a/released/packages/coq-algorand/coq-algorand.1.4/opam
+++ b/released/packages/coq-algorand/coq-algorand.1.4/opam
@@ -18,9 +18,9 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.14"}
-  "coq-mathcomp-ssreflect" {>= "1.14"}
+  "coq-mathcomp-ssreflect" {>= "1.14" & < "2.0"}
   "coq-mathcomp-algebra" 
-  "coq-mathcomp-finmap" {>= "1.5.1"}
+  "coq-mathcomp-finmap" {>= "1.5.1" & < "2.0"}
   "coq-mathcomp-analysis" {>= "0.5.0"}
   "coq-mathcomp-zify" 
   "coq-record-update" 

--- a/released/packages/coq-disel/coq-disel.2.3/opam
+++ b/released/packages/coq-disel/coq-disel.2.3/opam
@@ -20,7 +20,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {>= "8.14"}
-  "coq-mathcomp-ssreflect" {>= "1.13"}
+  "coq-mathcomp-ssreflect" {>= "1.13" & < "2.0"}
   "coq-fcsl-pcm" {>= "1.7.0"}
   "coq-htt" {>= "1.2.0"}
 ]


### PR DESCRIPTION
MathComp 2.0 is not backwards compatible, so adjust some packages depending on it.