### PR TITLE
coq-fcsl-pcm.1.8.0 and coq-htt.1.3.0 are compatible with Coq 8.18

### DIFF
--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.8.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.8.0/opam
@@ -21,7 +21,7 @@ This library relies on propositional and functional extentionality axioms."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.15" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.15" & < "8.19~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.15.0" & < "1.18~") | (= "dev") }
   "coq-mathcomp-algebra" 
 ]

--- a/released/packages/coq-htt/coq-htt.1.3.0/opam
+++ b/released/packages/coq-htt/coq-htt.1.3.0/opam
@@ -30,7 +30,7 @@ that HTT implements Separation logic as a shallow embedding in Coq."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" { (>= "8.15" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.15" & < "8.19~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.17.0" & < "1.18~") | (= "dev") }
   "coq-mathcomp-algebra" 
   "coq-mathcomp-fingroup" 


### PR DESCRIPTION
Tested locally with Coq 8.18+rc1, so release manager will ensure 8.18.0 compatibility.

cc: @clayrat 