### PR TITLE
Package coq-elpi.1.19.2

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.1.19.2/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.19.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Elpi extension language for Coq"
+description: """\
+Coq-elpi provides a Coq plugin that embeds ELPI.
+It also provides a way to embed Coq's terms into λProlog using
+the Higher-Order Abstract Syntax approach
+and a way to read terms back.  In addition to that it exports to ELPI a
+set of Coq's primitives, e.g. printing a message, accessing the
+environment of theorems and data types, defining a new constant and so on.
+For convenience it also provides a quotation and anti-quotation for Coq's
+syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
+numbers, or `{{A -> B}}` to the representation of a product by unfolding
+ the `->` notation. Finally it provides a way to define new vernacular commands
+and
+new tactics."""
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: "Enrico Tassi"
+license: "LGPL-2.1-or-later"
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:λProlog"
+  "keyword:higher order abstract syntax"
+  "logpath:elpi"
+]
+homepage: "https://github.com/LPCIC/coq-elpi"
+bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
+depends: [
+  "stdlib-shims"
+  "elpi" {>= "1.16.5" & < "1.18.0~"}
+  "coq" {>= "8.18" & < "8.19~"}
+]
+build: [
+  [make "build" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN="]
+  [make "test" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"] {with-test}
+]
+install: [make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"]
+dev-repo: "git+https://github.com/LPCIC/coq-elpi"
+url {
+  src:
+    "https://github.com/LPCIC/coq-elpi/releases/download/v1.19.2/coq-elpi-1.19.2.tar.gz"
+  checksum: [
+    "md5=1833212081b53d29e8c631a86b9ff250"
+    "sha512=8c9be421f0bdb4a59676ef8033438d50320cc335a048bb0a9fd2c436861fe9e337314ad3bacd028be01f893c6740dc3db7310419f9ac4876740aecd8f78bb825"
+  ]
+}


### PR DESCRIPTION
### `coq-elpi.1.19.2`
Elpi extension language for Coq
Coq-elpi provides a Coq plugin that embeds ELPI.
It also provides a way to embed Coq's terms into λProlog using
the Higher-Order Abstract Syntax approach
and a way to read terms back.  In addition to that it exports to ELPI a
set of Coq's primitives, e.g. printing a message, accessing the
environment of theorems and data types, defining a new constant and so on.
For convenience it also provides a quotation and anti-quotation for Coq's
syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
numbers, or `{{A -> B}}` to the representation of a product by unfolding
 the `->` notation. Finally it provides a way to define new vernacular commands
and
new tactics.



---
* Homepage: https://github.com/LPCIC/coq-elpi
* Source repo: git+https://github.com/LPCIC/coq-elpi
* Bug tracker: https://github.com/LPCIC/coq-elpi/issues

---
:camel: Pull-request generated by opam-publish v2.0.3