### PR TITLE
coq-elpi.dev no longer compiles with Coq 8.18

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
@@ -13,7 +13,7 @@ install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 depends: [
   "stdlib-shims"
   "elpi" {>= "1.16.5" & < "1.18.0~"}
-  "coq" {>= "8.18"}
+  "coq" {= "dev"}
 ]
 tags: [
   "category:Miscellaneous/Coq Extensions"


### PR DESCRIPTION
Follow-up of https://github.com/coq/opam/pull/2668