### PR TITLE
fix(coq-mathcomp-ssreflect.dev): Relax elpi constraint to allow coq.8.16

### DIFF
--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -10,9 +10,11 @@ license: "CeCILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
-  "coq" {>= "8.16"}
+  ( ( "coq" {>= "8.16" & < "8.17~"} & "elpi" {>= "1.16.5"} ) |
+  # The line above can be removed at the time support for 8.16 is dropped
+    ( "coq" {>= "8.17"}
+      & "elpi" {>= "1.17.0"} ) )
   "coq-hierarchy-builder" {>= "1.5.0"}
-  "elpi" {>= "1.17.0"}
 ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]


### PR DESCRIPTION
Cc @gares @proux01 @palmskog 

Propagate coq-mathcomp-ssreflect.dev : math-comp.dev → opam-coq-archive

Related: https://github.com/math-comp/math-comp/pull/1057