### PR TITLE
Add coq-sail package

### DIFF
--- a/released/packages/coq-sail/coq-sail.0.16/opam
+++ b/released/packages/coq-sail/coq-sail.0.16/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Sail Devs <cl-sail-dev@lists.cam.ac.uk>"
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+homepage: "http://www.cl.cam.ac.uk/~pes20/sail/"
+bug-reports: "https://github.com/rems-project/coq-sail/issues"
+doc: "https://github.com/rems-project/sail/blob/sail2/README.md"
+license: "BSD-3-clause"
+dev-repo: "git+https://github.com/rems-project/coq-sail.git"
+build: [make "-C" "src" "HAVE_OPAM_BBV=yes"]
+install: [make "-C" "src" "install"]
+depends: [
+  "coq" {>= "8.14.0" & <= "8.17.1"}
+  "coq-bbv" {= "1.3"}
+]
+# Ensure that if we're building from Sail then the version is compatible
+conflicts: [
+  "sail" { != version }
+ ]
+synopsis:
+  "Support library for Sail, a language for describing the instruction semantics of processors"
+description:
+  """The support library for instruction-set semantics generated from Sail.
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+The Sail tool can be found in main opam repository."""
+tags: [
+  "logpath:Sail"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+]
+
+url {
+  src: "https://github.com/rems-project/coq-sail/archive/refs/tags/0.16.tar.gz"
+  checksum: "sha256=c96108ca40739b67affd3da542df3a70e2e036762755ce0e4feb8aa9820e3248"
+}


### PR DESCRIPTION
This is the support library for Coq models generated by the Sail instruction set specification tool.