### PR TITLE
CompCert 3.13 (32 bits)

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.13/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.13/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+name: "coq-compcert-32"
+synopsis: "The CompCert C compiler (32 bit)"
+description: """\
+This package installs the 32 bit version of CompCert.
+For coexistence with the 64 bit version, the files are installed in:
+%{prefix}%/variants/compcert32/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert32/lib/compcert  (C library)
+%{lib}%/coq-variant/compcert32/compcert (Coq library)
+Please note that the coq module path is compcert and not compcert32,
+so the files cannot be directly Required as compcert32.
+Instead -Q or -R options must be used to bind the compcert32 folder
+to the module path compcert. This is more convenient if one development
+supports both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert32.
+Please also note that the binary folder is usually not in the path."""
+maintainer: "Xavier Leroy"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+license: "INRIA Non-Commercial License Agreement"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert32"
+  "date:2023-07-04"
+]
+homepage: "https://compcert.org/"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+depends: [
+  "coq" {>= "8.12.0" & < "8.18~"}
+  "menhir" {>= "20190626" & != "dev"}
+  "ocaml" {>= "4.05.0" & < "5~"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+available: os != "macos" & os != "cygwin" & os != "win32"
+build: [
+  [
+    "./configure"
+    "ia32-linux" {os = "linux"}
+    "-prefix"
+    "%{prefix}%/variants/compcert32"
+    "-install-coqdev"
+    "-clightgen"
+    "-use-external-Flocq"
+    "-use-external-MenhirLib"
+    "-coqdevdir"
+    "%{lib}%/coq-variant/compcert32/compcert"
+    "-ignore-coq-version"
+  ]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.13.tar.gz"
+  checksum:
+    "sha512=a1d493ad9d85c54cd3b5f6cbf0a01b4568044a5df1357366bc18afc82ceefec8bb431d163ab4743e2962d5c77f9becdbffec79604f3cf738ee6b21b35a7fadf7"
+}


### PR DESCRIPTION
Based on Michael Soegtrop's packages for CompCert 3.12.

Support for Cygwin 32 bits was removed upstream, because the Cygwin project no longer supports 32-bit mode, so all that remains is 32-bit Linux.
