### PR TITLE
coq-quickchick.2.0.0 does not work on 8.18

### DIFF
--- a/released/packages/coq-quickchick/coq-quickchick.2.0.0/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.2.0.0/opam
@@ -9,7 +9,7 @@ license: "MIT"
 
 build: [
   [make "compat"]
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc}]
 ]
 depends: [
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "menhir" {build}
   "cppo" {build & >= "1.6.8"}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.15~" & < "8.18"}
   "coq-ext-lib"
   "coq-mathcomp-ssreflect"
   "coq-simple-io"


### PR DESCRIPTION
cc: @lemonidas @liyishuai @Lysxia 

Error seems to be unrelated to MathComp:
```
File "./src/Instances.v", line 309, characters 2-26:
Error: Cannot infer an instance of type "A" for the variable a in
environment:
A : Type
X : EnumSized A
H : forall s : nat, SizeMonotonic (enumSized s)
H0 : SizedMonotonic enumSized
prodCorrectSized : set_eq
                     (fun n : A => exists s : nat, semProd (enumSized s) n)
                     setT
B : Type
X0 : EnumSized B
H2 : forall s : nat, SizeMonotonic (enumSized s)
H3 : SizedMonotonic enumSized
H4 : CorrectSized enumSized
a : A
b : B
```