### PR TITLE
bump lower bound for ceres 0.4.1

### DIFF
--- a/released/packages/coq-ceres/coq-ceres.0.4.1/opam
+++ b/released/packages/coq-ceres/coq-ceres.0.4.1/opam
@@ -7,7 +7,7 @@ license: "MIT"
 dev-repo: "git+https://github.com/Lysxia/coq-ceres.git"
 depends: [
   "dune" {>= "2.8"}
-  "coq" {>= "8.8~"}
+  "coq" {>= "8.8.2"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
As seen in https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.6/released/8.8.0/ceres/0.4.1.html