### PR TITLE
patch coq-stdpp.1.8.0 for Coq 8.18, dropping 8.12 support

### DIFF
--- a/released/packages/coq-stdpp/coq-stdpp.1.8.0/files/curry.patch
+++ b/released/packages/coq-stdpp/coq-stdpp.1.8.0/files/curry.patch
@@ -1,0 +1,12 @@
+--- coq-stdpp.orig/stdpp/base.v
++++ coq-stdpp/stdpp/base.v
+@@ -696,9 +696,7 @@
+ (** The Coq standard library swapped the names of curry/uncurry, see
+ https://github.com/coq/coq/pull/12716/
+ FIXME: Remove this workaround once the lowest Coq version we support is 8.13. *)
+-Notation curry := prod_uncurry.
+ Global Instance: Params (@curry) 3 := {}.
+-Notation uncurry := prod_curry.
+ Global Instance: Params (@uncurry) 3 := {}.
+
+ Definition uncurry3 {A B C D} (f : A → B → C → D) (p : A * B * C) : D :=

--- a/released/packages/coq-stdpp/coq-stdpp.1.8.0/opam
+++ b/released/packages/coq-stdpp/coq-stdpp.1.8.0/opam
@@ -33,9 +33,10 @@ tags: [
 ]
 
 depends: [
-  "coq" { (>= "8.12" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.13" & < "8.19~") | (= "dev") }
 ]
 
+patches: ["curry.patch"]
 build: ["./make-package" "stdpp" "-j%{jobs}%"]
 install: ["./make-package" "stdpp" "install"]
 


### PR DESCRIPTION
coq-stdpp.1.8.0 breaks on Coq 8.18.0 due to changes in Stdlib related to `curry` definitions. Here is a conditional patch to fix this while preserving compatibility with earlier Coq.

This is useful to let stdpp users migrate to 8.18.0 before stdpp 1.9.0 comes out, so hopefully is fine with you @RalfJung?