### PR TITLE
[coq-neural-net-interp-computed] Document incompatibility with Coq 8.18

### DIFF
--- a/extra-dev/packages/coq-neural-net-interp-computed/coq-neural-net-interp-computed.dev/opam
+++ b/extra-dev/packages/coq-neural-net-interp-computed/coq-neural-net-interp-computed.dev/opam
@@ -9,7 +9,7 @@ license: "MIT"
 build: [make "-j%{jobs}%" "computed"]
 install: []
 depends: [
-  "coq" {>= "8.17~"}
+  "coq" {>= "8.17~" & ( < "8.18~" | > "8.18.0" )}
 ]
 conflict-class: [
   "coq-neural-net-interp"


### PR DESCRIPTION
Compatibility is blocking on https://github.com/coq/coq/pull/17909 being backported