### PR TITLE
coq-ott.0.32 requires 8.6 or later

### DIFF
--- a/released/packages/coq-ott/coq-ott.0.32/opam
+++ b/released/packages/coq-ott/coq-ott.0.32/opam
@@ -18,7 +18,7 @@ patches: ["locality-warnings.patch"]
 build: [make "-j%{jobs}%" "-C" "coq"]
 install: [make "-C" "coq" "install"]
 depends: [
-  "coq" {>= "8.5.3"}
+  "coq" {>= "8.6"}
 ]
 conflicts: [
   "ott" { != version }


### PR DESCRIPTION
Via bench, rule out build failures.