### PR TITLE
Release coq-mathcomp-algebra-tactics.1.2.2

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
@@ -23,8 +23,8 @@ ring/field expressions before applying the proof procedures."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16"}
-  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq" {>= "8.16" & < "8.19~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.1~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}
@@ -38,5 +38,6 @@ authors: [
   "Pierre Roux"
 ]
 url {
-  src: "git+https://github.com/math-comp/algebra-tactics.git#master"
+  src: "https://github.com/math-comp/algebra-tactics/archive/refs/tags/1.2.2.tar.gz"
+  checksum: "sha256=e2c5b2f5ed9dec2db3ac436ebed9e271b2dd760fe5372c57e06fc0619e97a2e4"
 }


### PR DESCRIPTION
https://github.com/math-comp/algebra-tactics/releases/tag/1.2.2