### PR TITLE
upper bound for coq-mathcomp-odd-order.1.14.0

### DIFF
--- a/released/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.1.14.0/opam
+++ b/released/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.1.14.0/opam
@@ -11,7 +11,7 @@ build: [
 install: [ make "install" ]
 depends: [
   "ocaml"
-  "coq-mathcomp-character" { (>= "1.12.0") | (= "dev") }
+  "coq-mathcomp-character" {>= "1.12.0" & < "1.16~"}
 ]
 tags: [ "keyword:finite groups" "keyword:Feit Thompson theorem" "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
It doesn't work with MC 1.16.0 or later.