### PR TITLE
Fix license of coq-ltac-iter from "BSD" to "MIT"

### DIFF
--- a/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.0/opam
+++ b/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.0/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/gmalecha/coq-ltac-iter"
 dev-repo: "git+https://github.com/gmalecha/coq-ltac-iter.git"
 bug-reports: "https://github.com/gmalecha/coq-ltac-iter/issues"
 authors: ["Gregory Malecha"]
-license: "BSD"
+license: "MIT"
 build: [
   [make "-j%{jobs}%"]
 ]

--- a/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.1/opam
+++ b/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.1/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/gmalecha/coq-ltac-iter"
 dev-repo: "git+https://github.com/gmalecha/coq-ltac-iter.git"
 bug-reports: "https://github.com/gmalecha/coq-ltac-iter/issues"
 authors: ["Gregory Malecha"]
-license: "BSD"
+license: "MIT"
 build: [
   [make "-j%{jobs}%"]
 ]

--- a/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.2/opam
+++ b/released/packages/coq-ltac-iter/coq-ltac-iter.1.1.2/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/gmalecha/coq-ltac-iter"
 dev-repo: "git+https://github.com/gmalecha/coq-ltac-iter.git"
 bug-reports: "https://github.com/gmalecha/coq-ltac-iter/issues"
 authors: ["Gregory Malecha"]
-license: "BSD"
+license: "MIT"
 build: [
   [make "-j%{jobs}%"]
 ]


### PR DESCRIPTION
Note this is not my package.

"BSD" is not a valid spdx identifier. The upstream repo is licensed under MIT. Changing to match. CC @gmalecha.