### PR TITLE
Fix licenses for coq-geometric-algebra

### DIFF
--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/thery/GeometricAlgebra"
 bug-reports: "https://github.com/thery/GeometricAlgebra"
 dev-repo: "git+https://github.com/thery/GeometricAlgebra.git"
 authors : "Laurent Théry"
-license: "LGPL"
+license: "LGPL-2.1-only"
 build: [
   [make "-j%{jobs}%"]
 ]

--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
@@ -20,6 +20,6 @@ tags: [
   "logpath:GeometricAlgebra"
 ]
 url {
-  src: "https://github.com/thery/GeometricAlgebra/archive/v8,11.zip"
-  checksum: "md5=8539a242001444b6ef76f2b3507d4779"
+  src: "https://github.com/thery/GeometricAlgebra/archive/v8,11.tar.gz"
+  checksum: "md5=660cfe9c5a8ea7e7405a9015e37d99c9"
 }

--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.12/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.12/opam
@@ -20,6 +20,6 @@ tags: [
   "logpath:GeometricAlgebra"
 ]
 url {
-  src: "https://github.com/thery/GeometricAlgebra/archive/v8,12.zip"
-  checksum: "md5=0e0185d4efdb692a8f440796600e7063"
+  src: "https://github.com/thery/GeometricAlgebra/archive/v8,12.tar.gz"
+  checksum: "md5=c0682da10c8ca6ae12c204f9335ae020"
 }

--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.8/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.8/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/thery/GeometricAlgebra"
 bug-reports: "https://github.com/thery/GeometricAlgebra"
 dev-repo: "git+https://github.com/thery/GeometricAlgebra.git"
 authors : "Laurent Théry"
-license: "LGPL"
+license: "LGPL-2.1-only"
 build: [
   [make "-j%{jobs}%"]
 ]

--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.8/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.8/opam
@@ -19,6 +19,6 @@ depends: [
 synopsis: "Grassman Cayley and Clifford formalisations"
 flags: light-uninstall
 url {
-  src: "https://github.com/thery/GeometricAlgebra/archive/v8.8.zip"
-  checksum: "md5=12dfbc7869435e2777342fe0a0243283"
+  src: "https://github.com/thery/GeometricAlgebra/archive/v8.8.tar.gz"
+  checksum: "md5=2026059522901d82553ca58e8a7a6a2b"
 }


### PR DESCRIPTION
@thery can you confirm if this is correct? There is one opam file that is already under LGPL-2.1-only, but the source code doesn't seem to have any license. Except for recently, when it became MIT...