### PR TITLE
Package coq-ext-lib.0.12.0

### DIFF
--- a/released/packages/coq-ext-lib/coq-ext-lib.0.12.0/opam
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.12.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A library of Coq definitions, theorems, and tactics"
+description:
+  "A collection of theories and plugins that may be useful in other Coq developments."
+maintainer: "gmalecha@gmail.com"
+authors: "Gregory Malecha"
+license: "BSD-2-Clause"
+tags: "logpath:ExtLib"
+homepage: "https://github.com/coq-community/coq-ext-lib"
+bug-reports: "https://github.com/coq-community/coq-ext-lib/issues"
+depends: [
+  "ocaml"
+  "coq" {>= "8.9" & (< "8.10" | >= "8.11")}
+]
+build: [make "-j%{jobs}%" "theories"]
+run-test: [make "-j%{jobs}%" "examples"]
+install: [make "install"]
+dev-repo: "git+https://github.com/coq-community/coq-ext-lib.git"
+url {
+  src:
+    "https://github.com/coq-community/coq-ext-lib/archive/refs/tags/v0.12.0.tar.gz"
+  checksum: [
+    "md5=ab08c703d854fdb90f35cf40614e089a"
+    "sha512=8cf5853137f21bae34382b7e91278625cf18e7a484464832f69b634984b27d00adb290b0132a476547ebb657858ee80c3b67a9c699b8b19a5ae47a6b25b445d0"
+  ]
+}


### PR DESCRIPTION
### `coq-ext-lib.0.12.0`
A library of Coq definitions, theorems, and tactics
A collection of theories and plugins that may be useful in other Coq developments.



---
* Homepage: https://github.com/coq-community/coq-ext-lib
* Source repo: git+https://github.com/coq-community/coq-ext-lib.git
* Bug tracker: https://github.com/coq-community/coq-ext-lib/issues

---
:camel: Pull-request generated by opam-publish v2.2.0