### PR TITLE
relax some mathcomp constraints to accomodate 2.1

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
@@ -24,7 +24,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.16" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.1~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.2~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}

--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
@@ -16,7 +16,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.16" & < "8.19~")}
-  "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.1~")}
+  "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.2~")}
   "coq-mathcomp-algebra" 
 ]
 


### PR DESCRIPTION
`coq-mathcomp-zify` and `coq-mathcom-algebra-tactis` both work with `mathcomp 2.1`