### PR TITLE
fix: Mark coq-mathcomp < 2.1.0 not compatible with coq.dev

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.16.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.16.0/opam
@@ -8,7 +8,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.13" & < "8.19~") | (= "dev"))} ]
+depends: [ "coq" { (>= "8.13" & < "8.19~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.17.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.17.0/opam
@@ -8,7 +8,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.15" & < "8.19~") | (= "dev"))} ]
+depends: [ "coq" { (>= "8.15" & < "8.19~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
@@ -9,7 +9,7 @@ license: "CECILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
-  "coq" { ((>= "8.16" & < "8.19~") | (= "dev"))}
+  "coq" { (>= "8.16" & < "8.19~") }
   "coq-hierarchy-builder" { >= "1.4.0"}
 ]
 


### PR DESCRIPTION
See also https://gitlab.inria.fr/math-comp/docker-mathcomp/-/pipelines/875410

Cc @affeldt-aist @proux01 FYI

(& I removed the stalled images from https://hub.docker.com/r/mathcomp/mathcomp/tags?page=1&name=coq-dev)