### PR TITLE
Release fiat-crypto and dependencies

### DIFF
--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.6/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  # No reason to build compiler_ex since there's no install_compiler_ex target; the install_compiler target installs only compiler_noex
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "compiler_noex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+  "coq-bedrock2" {= "0.0.6"}
+  "coq-riscv" {= "0.0.4"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming (compiler part)"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  This package includes a verified compiler targeting RISC-V
+from this language.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.6.tar.gz"
+  checksum: "sha512=63a47ee2b4fe0780e70b7bdd708589093f6d666f9fa815d935a4df7053b3c5a2c75524cc668db61fc92d2f7b623d87c5a9e8cb6510f8c584ab4c385637b05687"
+}

--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.6/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.6/opam
@@ -15,8 +15,8 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.15~"}
-  "coq-bedrock2" {= "0.0.6"}
+  "coq" {>= "8.16~"}
+  "coq-bedrock2" {= version}
   "coq-riscv" {= "0.0.4"}
   "zarith" {>= "1.11"}
 ]

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.6/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "bedrock2_ex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_bedrock2"]
+run-test: [
+  [make "-j%{jobs}%" "-C" "bedrock2" "EXTERNAL_DEPENDENCIES=1" "test"]
+]
+depends: [
+  "conf-findutils" {build}
+  "conf-python-3" {build & with-test}
+  "coq" {>= "8.15~"}
+  "coq-coqutil" {= "0.0.3"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  A verified compiler targeting RISC-V from this language
+exists in the coq-bedrock2-compiler package on opam.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.6.tar.gz"
+  checksum: "sha512=63a47ee2b4fe0780e70b7bdd708589093f6d666f9fa815d935a4df7053b3c5a2c75524cc668db61fc92d2f7b623d87c5a9e8cb6510f8c584ab4c385637b05687"
+}

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.6/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.6/opam
@@ -18,8 +18,8 @@ run-test: [
 depends: [
   "conf-findutils" {build}
   "conf-python-3" {build & with-test}
-  "coq" {>= "8.15~"}
-  "coq-coqutil" {= "0.0.3"}
+  "coq" {>= "8.16~"}
+  "coq-coqutil" {= "0.0.4"}
   "zarith" {>= "1.11"}
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"

--- a/released/packages/coq-coqutil/coq-coqutil.0.0.4/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+]
+conflict-class: [
+  "coq-coqutil"
+]
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+description: """
+### coqutil -- Various Coq Utilities
+
+Contents:
+* [Datatypes](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Datatypes): Some utilities for existing datatypes, and new datatypes.
+* [Decidable](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Decidable.v): `BoolSpec`-based decidability typeclasses. Allows one to write `if MyType_eqb a b then ... else ...` where `MyType_eqb a b` returns a `bool`, instead of writing `if MyType_eq_dec a b then ... else ...` where `MyType_eq_dec a b` returns a `sumbool`, while still getting `a = b` and `a <> b` as hypotheses (as opposed to `MyType_eqb a b = true` and `MyType_eqb a b = false`) after destructing the `if` (need to use [`destr`](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Tactics/destr.v) instead of `destruct`). So one gets the benefits of `Sumbool` without getting its disadvantage of having to carry around proof terms, which can cause a blow-up under reduction if one is not careful.
+* [Map](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Map): A typeclass based map library allowing one to abstract over the concrete implementation of maps. The implementations have to be extensional, which excludes certain efficient implementations, but simplifies proofs, because one can `replace mapA with mapB` if one can prove that `mapA` and `mapB` have the same contents. Comes with a [solver](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Map/Solver.v) which works reasonably fast on most map goals we have encountered so far.
+* [Tactics](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Tactics): A collection of useful general-purpose tactics.
+* [Word](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Word): Fixed width words for any width, in the same typeclass based style as the map library. Designed for the case where all words have the same (potentially abstract) bit width. Therefore, it does not provide functions to concatenate and split words, which is better addressed by [bbv](https://github.com/mit-plv/bbv/).
+* [Z](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Z): Utilities to work with the `Z` type from Coq's standard library, including a tactic to prove `Z` equalities by splitting the equality into equalities on bit index ranges, a tactic to make `lia` capable of reasoning about goals with division and modulo, and a tactic to simplify expressions containing nested occurrences of `mod`, and more misc utilities.
+* Various macros, notations, and desirable default settings.
+
+Each feature is intended to be as minimal and as independent of the other features as possible, so that users can pick just what they need.
+"""
+tags: ["logpath:coqutil"]
+url {
+  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.4.tar.gz"
+  checksum: "sha512=d8edb84e9a68de786368b27212f500f8f472ffc72fd715facb89b66ad75b69319e40b42eb53a8e68212379aa5e21c0c5b827411ec1790f956d65762372f7d6be"
+}

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "coq" {>= "8.15~"}
   "coq-coqprime" {>= "1.2.0"}
-  "coq-rewriter" {>= "0.0.6" & <= "0.0.8"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.9"}
   "coq-rupicola" {= "0.0.7"}
   "coq-bedrock2-compiler" {= "0.0.5"}
 ]

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.24/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.24/opam
@@ -18,11 +18,11 @@ depends: [
   "conf-findutils" {build}
   "ocaml" {build & >= "4.08~"}
   "ocamlfind" {build}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.16~"}
   "coq-coqprime" {>= "1.2.0"}
-  "coq-rewriter" {>= "0.0.6" & <= "0.0.8"}
-  "coq-rupicola" {= "0.0.7"}
-  "coq-bedrock2-compiler" {= "0.0.5"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.9"}
+  "coq-rupicola" {= "0.0.8"}
+  "coq-bedrock2-compiler" {= "0.0.6"}
 ]
 conflict-class: [
   "coq-fiat-crypto"

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.24/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.24/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "coq" "standalone-ocaml"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build & >= "4.08~"}
+  "ocamlfind" {build}
+  "coq" {>= "8.15~"}
+  "coq-coqprime" {>= "1.2.0"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.8"}
+  "coq-rupicola" {= "0.0.7"}
+  "coq-bedrock2-compiler" {= "0.0.5"}
+]
+conflict-class: [
+  "coq-fiat-crypto"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis: "Cryptographic Primitive Code Generation by Fiat"
+description: """
+Coq code and proofs for a command-line binary that can synthesize proven-correct
+big-integer modular field arithmetic operations for cryptography.
+Target languages include C, Rust, Zig, Go, and bedrock2.
+"""
+tags: ["logpath:Crypto"]
+url {
+  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.0.24.tar.gz"
+  checksum: "sha512=eb1a871b7ec2469be78a95e677f39e238cb0b13228530e297f2d9b5e4808711a7ff2dde823aebd00d64505acc4f3fb580b6a9646b6523bd49ad7253257336f53"
+}

--- a/released/packages/coq-riscv/coq-riscv.0.0.4/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.4/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
-  "coq-coqutil" {= "0.0.3"}
+  "coq-coqutil" {>= "0.0.3" & <= "0.0.4"}
   "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.8/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.8/opam
@@ -16,8 +16,8 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.15~"}
-  "coq-bedrock2" {= "0.0.5"}
+  "coq" {>= "8.16~"}
+  "coq-bedrock2" {= "0.0.6"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rupicola.git"
 synopsis: "Gallina to imperative code compilation, currently in design phase"

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.8/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.8/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: [
+  "Clément Pit-Claudel <clement.pitclaudel@live.com>"
+  "Jade Philipoom"
+  "Dustin Jamner"
+  "Andres Erbsen"
+  "Adam Chlipala"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rupicola"
+bug-reports: "https://github.com/mit-plv/rupicola/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+  "coq-bedrock2" {= "0.0.5"}
+]
+dev-repo: "git+https://github.com/mit-plv/rupicola.git"
+synopsis: "Gallina to imperative code compilation, currently in design phase"
+tags: ["logpath:Rupicola"]
+url {
+  src: "https://github.com/mit-plv/rupicola/archive/refs/tags/v0.0.8.tar.gz"
+  checksum: "sha512=f163215f4e7027af4cc8d95263c0f1a11ce6e8752c7e992b50e1d77d2104f92872a79c55748517bcd7a162d960a0da8a68cfc908af532bf295a3bcb3d3ebd0aa"
+}


### PR DESCRIPTION
<details><summary>For future reference, most of the work was done with this script</summary>

```bash

pkg="$1"
oldver="$2"
newver="$3"

function usage() {
    printf "USAGE: %s PKG OLDVER NEWVER\n" "$0"
}

if [ -z "$pkg" ] || [ -z "$oldver" ] || [ -z "$newver" ]; then
    usage;
    exit 1;
fi

set -ex

cd "$(git rev-parse --show-toplevel)"
pwd
pushd "released/packages/coq-${pkg}"
oldopam="coq-${pkg}.${oldver}/opam"
newopam="coq-${pkg}.${newver}/opam"
mkdir -p "coq-${pkg}.${newver}"
cp -f "$oldopam" "$newopam"
git add "$newopam"
sed -i "s/${oldver}/${newver}/g" "$newopam"
url="$(grep -o '^\s*src: .*' "$newopam" | grep -o '"[^"]*"' | tr -d '"')"
wget "$url" -O "$newver.tar.gz"
sha512="$(sha512sum "$newver.tar.gz" | cut -d' ' -f1)"
sed -i 's/\(checksum:[^"]*"\)[^"]*\("\)/\1sha512='"${sha512}"'\2/g' "$newopam"
git diff "$newopam"
git add "$newopam"
```

```
./release-next.sh coqutil 0.0.3 0.0.4; ./release-next.sh bedrock2 0.0.5 0.0.6; ./release-next.sh bedrock2-compiler 0.0.5 0.0.6; ./release-next.sh rupicola 0.0.7 0.0.8; ./release-next.sh fiat-crypto 0.0.20 0.0.24
```
</details>