### PR TITLE
Add coq-library-fol for 8.17 and 8.18

### DIFF
--- a/released/packages/coq-library-fol/coq-library-fol.1.0+8.17/opam
+++ b/released/packages/coq-library-fol/coq-library-fol.1.0+8.17/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+version: "1.0+8.17"
+maintainer: "kirst@cs.uni-saarland.de"
+homepage: "https://github.com/uds-psl/coq-library-fol/"
+dev-repo: "git+https://github.com/uds-psl/coq-library-fol/"
+bug-reports: "https://github.com/uds-psl/coq-library-fol/issues"
+authors: [
+  "Dominik Kirst"
+  "Johannes Hostert"
+  "Andrej Dudenhefner"
+  "Yannick Forster"
+  "Marc Hermes"
+  "Mark Koch"
+  "Dominique Larchey-Wendling"
+  "Niklas Mück"
+  "Benjamin Peters"
+  "Gert Smolka"
+  "Dominik Wehr"
+]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.17" & < "8.18~"}
+  "coq-library-undecidability" {= "1.1+8.17"}
+]
+synopsis: "A Coq Library for First-Order Logic"
+url {
+  src: "https://github.com/uds-psl/coq-library-fol/archive/refs/tags/v1.0+8.17.tar.gz"
+  checksum: "sha256=367f7ed87d43148cc8d7f3f26e1a49c16cc801fd3e429e7a2db31f463f051f98"
+}
+

--- a/released/packages/coq-library-fol/coq-library-fol.1.0+8.18/opam
+++ b/released/packages/coq-library-fol/coq-library-fol.1.0+8.18/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+version: "1.0+8.18"
+maintainer: "kirst@cs.uni-saarland.de"
+homepage: "https://github.com/uds-psl/coq-library-fol/"
+dev-repo: "git+https://github.com/uds-psl/coq-library-fol/"
+bug-reports: "https://github.com/uds-psl/coq-library-fol/issues"
+authors: [
+  "Dominik Kirst"
+  "Johannes Hostert"
+  "Andrej Dudenhefner"
+  "Yannick Forster"
+  "Marc Hermes"
+  "Mark Koch"
+  "Dominique Larchey-Wendling"
+  "Niklas Mück"
+  "Benjamin Peters"
+  "Gert Smolka"
+  "Dominik Wehr"
+]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.18" & < "8.19~"}
+  "coq-library-undecidability" {= "1.1.1+8.18"}
+]
+synopsis: "A Coq Library for First-Order Logic"
+url {
+  src: "https://github.com/uds-psl/coq-library-fol/archive/refs/tags/v1.0+8.18.tar.gz"
+  checksum: "sha256=777796790b0ede24cffbbb25f92c4c51eea53477518600ca1b7ce85b7810a5e7"
+}
+


### PR DESCRIPTION
Efforts are underway to add `coq-library-fol`, the [Coq Library for First-Order Logic](https://github.com/uds-psl/coq-library-fol), to the Coq platform, as discussed in https://github.com/coq/platform/issues/386. This (initial) release is part of this effort.

CC @dominik-kirst