### PR TITLE
Fix failing build for coq-library-fol

### DIFF
--- a/released/packages/coq-library-fol/coq-library-fol.1.0+8.17/opam
+++ b/released/packages/coq-library-fol/coq-library-fol.1.0+8.17/opam
@@ -31,6 +31,6 @@ depends: [
 synopsis: "A Coq Library for First-Order Logic"
 url {
   src: "https://github.com/uds-psl/coq-library-fol/archive/refs/tags/v1.0+8.17.tar.gz"
-  checksum: "sha256=367f7ed87d43148cc8d7f3f26e1a49c16cc801fd3e429e7a2db31f463f051f98"
+  checksum: "sha256=6e8921d46da6d6541b1d8cb1af979cb3de0446d1c9fe9bebd95cd2077b1402f6"
 }
 

--- a/released/packages/coq-library-fol/coq-library-fol.1.0+8.18/opam
+++ b/released/packages/coq-library-fol/coq-library-fol.1.0+8.18/opam
@@ -31,6 +31,6 @@ depends: [
 synopsis: "A Coq Library for First-Order Logic"
 url {
   src: "https://github.com/uds-psl/coq-library-fol/archive/refs/tags/v1.0+8.18.tar.gz"
-  checksum: "sha256=777796790b0ede24cffbbb25f92c4c51eea53477518600ca1b7ce85b7810a5e7"
+  checksum: "sha256=9be91c51601e2a6afba5f71d44bdd1a5775345d2140c3a401d7c26ff58ad6351"
 }
 


### PR DESCRIPTION
https://github.com/coq/opam/pull/2825 failed to pass CI due to an OOM error. This was easily fixed by rewriting a certain function to not have several deeply-nested pattern matches.

Unfortunately, I failed to properly push these changes. Now the checksum in the `opam` file is wrong. This PR fixes this.

I'm sorry for the inconvenience.