### PR TITLE
coq-fcsl-pcm.1.8.0 and coq-htt.1.3.0 are compatible with MathComp 1.18.0

### DIFF
--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.8.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.8.0/opam
@@ -22,7 +22,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.15" & < "8.19~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.15.0" & < "1.18~") | (= "dev") }
+  "coq-mathcomp-ssreflect" {>= "1.15.0" & < "1.19~"}
   "coq-mathcomp-algebra" 
 ]
 

--- a/released/packages/coq-htt/coq-htt.1.3.0/opam
+++ b/released/packages/coq-htt/coq-htt.1.3.0/opam
@@ -31,7 +31,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" { (>= "8.15" & < "8.19~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.17.0" & < "1.18~") | (= "dev") }
+  "coq-mathcomp-ssreflect" {>= "1.17.0" & < "1.19~"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-fingroup" 
   "coq-fcsl-pcm" { (>= "1.8.0" & < "1.9~") | (= "dev") }


### PR DESCRIPTION
cc: @aleksnanevski @clayrat 

Note that `coq-mathcomp-ssreflect.dev` uses MathComp 2.