### PR TITLE
Allow Coq 8.18 for coq-deriving and coq-extructures

### DIFF
--- a/released/packages/coq-deriving/coq-deriving.0.1.1/opam
+++ b/released/packages/coq-deriving/coq-deriving.0.1.1/opam
@@ -10,7 +10,7 @@ build: [ make "-j" "%{jobs}%" "test" {with-test} ]
 install: [ make "install" ]
 depends: [
   "coq" { (>= "8.11" & < "8.19~") | (= "dev") }
-  "coq-mathcomp-ssreflect" {>= "1.11"}
+  "coq-mathcomp-ssreflect" {>= "1.11" & < "2.0"}
 ]
 
 tags: [

--- a/released/packages/coq-deriving/coq-deriving.0.1.1/opam
+++ b/released/packages/coq-deriving/coq-deriving.0.1.1/opam
@@ -9,7 +9,7 @@ license: "MIT"
 build: [ make "-j" "%{jobs}%" "test" {with-test} ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.11" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.11" & < "8.19~") | (= "dev") }
   "coq-mathcomp-ssreflect" {>= "1.11"}
 ]
 

--- a/released/packages/coq-extructures/coq-extructures.0.3.1/opam
+++ b/released/packages/coq-extructures/coq-extructures.0.3.1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {(>= "8.11" & < "8.18~")}
+  "coq" {(>= "8.11" & < "8.19~")}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.19~")}
   "coq-deriving" {(>= "0.1" & < "0.2~")}
 ]


### PR DESCRIPTION
This PR relaxed version restrictions to allow Coq 8.18 for two related packages for which this has been tested.