### PR TITLE
Update coq-fiat-crypto{,-with-bedrock}.dev install

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,14 +11,18 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "coq" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "coq" "standalone-unified-ocaml"]
 ]
-install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+install: [
+  [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "BINDIR=%{bin}%" "install" "install-standalone-unified-ocaml"]
+  ["etc/test-run-fiat-crypto-silent.sh" "%{bin}%/fiat_crypto"] {with-test}
+  ["etc/test-run-fiat-crypto-silent.sh" "fiat_crypto"] {with-test}
+]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & >= "4.08~"}
   "ocamlfind" {build}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.16~"}
   "coq-coqprime"
   "coq-rewriter"
 ]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -11,14 +11,18 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "coq-without-bedrock2" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "coq-without-bedrock2" "standalone-unified-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
+install: [
+  [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-unified-ocaml"]
+  ["etc/test-run-fiat-crypto-silent-no-bedrock2.sh" "%{bin}%/fiat_crypto"] {with-test}
+  ["etc/test-run-fiat-crypto-silent-no-bedrock2.sh" "fiat_crypto"] {with-test}
+]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & >= "4.08~"}
   "ocamlfind" {build}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.16~"}
   "coq-coqprime"
   "coq-rewriter"
   "coq-coqutil"


### PR DESCRIPTION
We now generate (and install) a single unified binary, rather than a collection.  There's also a short test to make sure it's installed correctly.