### PR TITLE
coq-infotheo.0.5.2 works on Coq 8.18 and MathComp 1.18

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.5.2/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.5.2/opam
@@ -17,12 +17,12 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.17" & < "8.18~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.16.0" & < "1.18~") | (= "dev") }
-  "coq-mathcomp-fingroup" { (>= "1.16.0" & < "1.18~") | (= "dev")  }
-  "coq-mathcomp-algebra" { (>= "1.16.0" & < "1.18~") | (= "dev")  }
-  "coq-mathcomp-solvable" { (>= "1.16.0" & < "1.18~") | (= "dev")  }
-  "coq-mathcomp-field" { (>= "1.16.0" & < "1.18~") | (= "dev")  }
+  "coq" {>= "8.17" & < "8.19~"}
+  "coq-mathcomp-ssreflect" {>= "1.16.0" & < "1.19~"}
+  "coq-mathcomp-fingroup"
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-solvable"
+  "coq-mathcomp-field"
   "coq-mathcomp-analysis" { (>= "0.5.4") & (< "0.7~")}
   "coq-hierarchy-builder" { >= "1.3.0" }
 ]


### PR DESCRIPTION
Only use ssreflect version for MathComp, since it determines versions for fingroup, algebra, field, solvable.

cc: @affeldt-aist 