### PR TITLE
coq-libhyps v 2.0.8. unplugging `especialize`.

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.2.0.8/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.2.0.8/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Pierre.Courtieu@lecnam.net"
+synopsis: "Hypotheses manipulation library"
+
+homepage: "https://github.com/Matafou/LibHyps"
+dev-repo: "git+https://github.com/Matafou/LibHyps.git"
+bug-reports: "https://github.com/Matafou/LibHyps/issues"
+doc: "https://github.com/Matafou/LibHyps/blob/master/Demo/demo.v"
+license: "MIT"
+
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+
+install: [make "install"]
+
+depends: [
+  "coq" {(>= "8.11" & < "8.19~") | (= "dev")}
+]
+
+tags: [
+  "keyword:proof environment manipulation"
+  "keyword:forward reasoning"
+  "keyword:hypothesis naming"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:LibHyps"
+  "date:2023-12-17"
+]
+
+authors: [
+ "Pierre Courtieu"
+]
+
+description: "
+This library defines a set of tactics to manipulate hypothesis
+individually or by group. In particular it allows applying a tactic on
+each hypothesis of a goal, or only on *new* hypothesis after some
+tactic. Examples of manipulations: automatic renaming, subst, revert,
+or any tactic expecting a hypothesis name as argument.
+
+It DOES NOT provide ANYMORE the especialize tactic to ease forward
+reasoning by instantianting one, several or all premisses of a
+hypothesis. Ths is due to coq's specialize being less permissive about
+evars. This may be fixed in the future.
+"
+
+url {
+  src: "https://github.com/Matafou/LibHyps/archive/libhyps-2.0.8.tar.gz"
+  checksum: "sha512=5d9799d2284101b5fc61ae3239f08f7e92418369bf0ed6a326261eb8e129470cbcbb4bba50fbf4d1a1a350a279cc50b45590be4635f083e4a4d6875ef7c3bf8f"
+}


### PR DESCRIPTION
Fix the previous release (test failed).