### PR TITLE
pocklington.8.12.0 compiles with Coq 8.17 and 8.18

### DIFF
--- a/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
+++ b/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
@@ -14,7 +14,7 @@ large natural numbers. Includes a formal proof of Fermat's little theorem."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.7" & < "8.17~"}
+  "coq" {>= "8.7" & < "8.19~"}
 ]
 
 tags: [


### PR DESCRIPTION
according to coq-nix-toolbox