### PR TITLE
coq-simple-io.1.8.0 compiles with Coq 8.19+rc1

### DIFF
--- a/released/packages/coq-simple-io/coq-simple-io.1.8.0/opam
+++ b/released/packages/coq-simple-io/coq-simple-io.1.8.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
-  "coq" {>= "8.11" & < "8.19~"}
+  "coq" {>= "8.11" & < "8.20~"}
   "coq-ext-lib" {>= "0.10.0"}
   "ocamlbuild" {with-test & >= "0.9.0"}
   "cppo" {build & >= "1.6.8"}


### PR DESCRIPTION
according to coq-nix-toolbox