### PR TITLE
bonak: bump coq and dune versions

### DIFF
--- a/extra-dev/packages/bonak/bonak.dev/opam
+++ b/extra-dev/packages/bonak/bonak.dev/opam
@@ -9,8 +9,8 @@ homepage: "https://github.com/artagnon/bonak"
 bug-reports: "https://github.com/artagnon/bonak/issues"
 dev-repo: "git+https://github.com/artagnon/bonak"
 depends: [
-  "coq"  { >= "8.16.1" }
-  "dune" { >= "3.6.0" }
+  "coq"  { >= "8.18.0" }
+  "dune" { >= "3.9.1" }
 ]
 build: [
   ["dune" "build"]


### PR DESCRIPTION
The latest supported version of dune in coq-action is 3.9.1, and coq 8.18.0 has been released. Bump dune and coq to these versions in bonak.opam as part of routine housekeeping.