### PR TITLE
Package coq-menhirlib.20231231

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20231231/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20231231/opam
@@ -1,0 +1,35 @@
+
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != version }
+]
+tags: [
+  "date:2023-12-31"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20231231/archive.tar.gz"
+  checksum: [
+    "md5=799748bc3b7a542798a85956c7863865"
+    "sha512=620ff3443143535e03ac98c5e8ee2ddf9ba48f8cfe441302118def1da3e03ffac7f48d4d4cb129766b625ecad0fb341da1baa0169dee8b6d07a5b0bbb735cf2f"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20231231`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.3.0