### PR TITLE
MathComp 2.0 is not compatible with HB 1.7

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
@@ -10,7 +10,7 @@ build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
   "coq" { (>= "8.16" & < "8.19~") }
-  "coq-hierarchy-builder" { >= "1.4.0"}
+  "coq-hierarchy-builder" { (>= "1.4.0" & < "1.7~") }
 ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]


### PR DESCRIPTION
```
### output ###
# [...]
# inside the section and not at all outside the section.
# Use attribute #[clearbody] to get the current behaviour of clearing the body
# at the start of proofs in a forward compatible way.
# [opaque-let,deprecated-since-8.18,deprecated,default]
# File "./order.v", line 4806, characters 0-138:
# Error: Attribute infer.T is not supported
```