### PR TITLE
deriving.0.2.0 compiles on Coq 8.19

### DIFF
--- a/released/packages/coq-deriving/coq-deriving.0.2.0/opam
+++ b/released/packages/coq-deriving/coq-deriving.0.2.0/opam
@@ -9,7 +9,7 @@ license: "MIT"
 build: [ make "-j" "%{jobs}%" "test" {with-test} ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.17" & < "8.19~") | (= "dev") }
+  "coq" { (>= "8.17" & < "8.20~") | (= "dev") }
   "coq-mathcomp-ssreflect" {>= "2.0"}
 ]
 


### PR DESCRIPTION
Tested on Nix: https://github.com/coq-community/coq-nix-toolbox/pull/196