### PR TITLE
coq-mathcomp-zify.1.5.0+2.0+8.16 compiles on Coq 8.19

### DIFF
--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
@@ -15,8 +15,8 @@ by extending the zify tactic."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16" & < "8.19~")}
-  "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.2~")}
+  "coq" {(>= "8.16" & < "8.20~")}
+  "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.3~")}
   "coq-mathcomp-algebra" 
 ]
 


### PR DESCRIPTION
tested on Nix: https://github.com/coq-community/coq-nix-toolbox/pull/196