### PR TITLE
mathcomp-real-closed.2.0.0 compiles on Coq 8.19

### DIFF
--- a/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
+++ b/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
@@ -18,7 +18,7 @@ library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.19~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.20~") | (= "dev")}
   "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
 

--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.0/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.0/opam
@@ -17,7 +17,7 @@ order theory of real closed field, through quantifier elimination."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.19"}
+  "coq" {>= "8.16" & < "8.20~"}
   "coq-mathcomp-ssreflect" {>= "2.0.0"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-field"


### PR DESCRIPTION
Tested on Nix: https://github.com/coq-community/coq-nix-toolbox/pull/196

ci-skip: coq-mathcomp-bigenough.1.0.1
