### PR TITLE
coq-mathcomp-algebra-tactics.1.2.2 is compatible with MathComp 2.2

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.2/opam
@@ -24,7 +24,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.16" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.2~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.3~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}


### PR DESCRIPTION
but not with Coq 8.19 (I will double-check). So I will have to do a release.