### PR TITLE
coq-reglang.1.1.3 and coq-mathcomp-finmap.1.5.2 work on 1.19.0/8.19

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
@@ -17,8 +17,8 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.13" & < "8.19~") | (= "dev") }
-  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.19~"}
+  "coq" { (>= "8.13" & < "8.20~") | (= "dev") }
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.20~"}
 ]
 
 tags: [

--- a/released/packages/coq-reglang/coq-reglang.1.1.3/opam
+++ b/released/packages/coq-reglang/coq-reglang.1.1.3/opam
@@ -18,8 +18,8 @@ decidability results and closure properties of regular languages."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.10" & < "8.19"}
-  "coq-mathcomp-ssreflect" {>= "1.11" & < "1.19"}
+  "coq" {>= "8.10" & < "8.20"}
+  "coq-mathcomp-ssreflect" {>= "1.11" & < "1.20"}
 ]
 
 tags: [


### PR DESCRIPTION
CI tests 1.19.0/8.18, locally tested 8.19.

cc: @CohenCyril @proux01 