### PR TITLE
mathcomp-word.2.2 compiles with MC 1.19.0

### DIFF
--- a/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.2/opam
+++ b/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.2/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.8"}
   "coq" {>= "8.12"}
-  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.19~"}
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.20~"}
   "coq-mathcomp-algebra"
 ]
 tags: [


### PR DESCRIPTION
Tested on Nix: https://github.com/NixOS/nixpkgs/pull/281290