### PR TITLE
Flocq 4.1 does not compile on Coq 8.19

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.4.1.2/opam
+++ b/released/packages/coq-flocq/coq-flocq.4.1.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.12"}
+  "coq" {>= "8.12" & < "8.19~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-flocq/coq-flocq.4.1.3/opam
+++ b/released/packages/coq-flocq/coq-flocq.4.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.12"}
+  "coq" {>= "8.12" & < "8.19~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]


### PR DESCRIPTION
@silene master is fine (since it's in Coq CI) but looks like a release is needed. Then latest Coquelicot is fine and https://gitlab.inria.fr/coqinterval/interval/-/merge_requests/12 should be enough for interval.