### PR TITLE
weaker requirement for mathcomp

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.2.0.0/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.0.0/opam
@@ -27,7 +27,7 @@ bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
 depends: [
   "ocaml" {>= "4.10.0"}
   "stdlib-shims"
-  "elpi" {>= "1.18.1" & < "1.19.0~"}
+  "elpi" {>= "1.18.1" & < "1.18.2~"}
   "coq" {>= "8.18" & < "8.19~"}
   "dot-merlin-reader" {with-dev}
   "ocaml-lsp-server" {with-dev}

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.1/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.1/opam
@@ -21,8 +21,8 @@ ring/field expressions before applying the proof procedures."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.19~"}
-  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.19~"}
+  "coq" {>= "8.16" & < "8.20~"}
+  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.20~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.1.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}


### PR DESCRIPTION
We observed that opam cannot use algebra-tactics with mathcomp 1.19.0 and are wondering whether this is a genuine restriction. @proux01 @pi8027 @t6s 