### PR TITLE
Release of SMTCoq 2.2

### DIFF
--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.13/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.13/opam
@@ -35,7 +35,8 @@ authors: [
 synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
 description: """
 - a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
-- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination"""
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
 url {
   src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.13"
 }

--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.14/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.14/opam
@@ -36,7 +36,8 @@ authors: [
 synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
 description: """
 - a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
-- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination"""
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
 url {
   src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.14"
 }

--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.15/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.15/opam
@@ -36,7 +36,8 @@ authors: [
 synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
 description: """
 - a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
-- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination"""
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
 url {
   src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.15"
 }

--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.17/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.17/opam
@@ -13,7 +13,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1" }
   "num"
-  "coq" {>= "8.16~" & < "8.17~"}
+  "coq" {>= "8.17~" & < "8.18~"}
 ]
 tags: [ 
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
@@ -39,5 +39,5 @@ description: """
 - decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
 - abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
 url {
-  src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.16"
+  src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.17"
 }

--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.18/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.18/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.18~" & < "8.19~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.18"
+}

--- a/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.19/opam
+++ b/extra-dev/packages/coq-smtcoq/coq-smtcoq.dev+8.19/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.19~" & < "8.20~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "git+https://github.com/smtcoq/smtcoq.git#coq-8.19"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.13/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.13/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "coq" {>= "8.13~" & < "8.14~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.13.tar.gz"
+  checksum: "sha512=b90f0248c4e5d264f334b8ea56854514584adfee832c9e2073dda9bac9553492a97f2cd8e23ec6d62e3d55f070c6101fb089ccebb270b596fcf6a3a7b85d45b0"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.14/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.14/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.14~" & < "8.15~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.14.tar.gz"
+  checksum: "sha512=51e5a1847f84a46e641f024ddee1695224d417ae75ae411eced80b4ffa69fa6f1727839c24e3f638a4c98e003e6ce8cd9ddd5a1b2d273331863619e430033570"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.15/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.15/opam
@@ -41,5 +41,5 @@ description: """
 - abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
 url {
   src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.15.tar.gz"
-  checksum: "25804556a1e65e2b2d20d6c2d691133531ad1d290b29765d8d3bb5c0a733cf46d6ca04d47e9b4dc6f683dbdeec8bdf2dd310081219e42b7d8baf68200ace1af9"
+  checksum: "sha512=25804556a1e65e2b2d20d6c2d691133531ad1d290b29765d8d3bb5c0a733cf46d6ca04d47e9b4dc6f683dbdeec8bdf2dd310081219e42b7d8baf68200ace1af9"
 }

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.15/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.15/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.15~" & < "8.16~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.15.tar.gz"
+  checksum: "25804556a1e65e2b2d20d6c2d691133531ad1d290b29765d8d3bb5c0a733cf46d6ca04d47e9b4dc6f683dbdeec8bdf2dd310081219e42b7d8baf68200ace1af9"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.16/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.16/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.16~" & < "8.17~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.16.tar.gz"
+  checksum: "sha512=bff6ab19c7850beff8f2a11e6db847b9e5910c86dc76d3cca66fd22088e3bac8d7bc751ba1e3e731f9b52282873d10e793fbd0e38241b1d24e476356bc2c2e71"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.17/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.17/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.17~" & < "8.18~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.17.tar.gz"
+  checksum: "sha512=dd1c2442be3b13583c98aa3f8d578d282abbed8805177c1bdc2c77ad239bf0764882110e380251e4c55dd1f060569a51ec225665aca399d15430deaf74adb976"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.18/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.18/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.18~" & < "8.19~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.18.tar.gz"
+  checksum: "sha512=461e82d49cf708bfc7021f5cd35dc46d3dfeaf680c8bdd306247f5807b2c7d29824e7892146f248346ad74b5249cd3ae60b56c698d82f636f4a6bf8dcfa49bf5"
+}

--- a/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.19/opam
+++ b/released/packages/coq-smtcoq/coq-smtcoq.2.2+8.19/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "ckeller@lmf.cnrs.fr"
+homepage: "https://smtcoq.github.io/"
+dev-repo: "git+https://github.com/smtcoq/smtcoq.git"
+bug-reports: "https://github.com/smtcoq/smtcoq/issues"
+license: "CECILL-C"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" }
+  "num"
+  "coq" {>= "8.19~" & < "8.20~"}
+]
+tags: [ 
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword: SMT"
+  "keyword: SAT"
+  "keyword: automation"
+  "logpath:SMTCoq"
+]
+authors: [ 
+ "Michaël Armand"
+ "Valentin Blot"
+ "Amina Bousalem"
+ "Boris Djalal"
+ "Quentin Garchery"
+ "Benjamin Grégoire"
+ "Chantal Keller"
+ "Burak Ekici"
+ "Alain Mebsout"
+]
+synopsis: "A Coq plugin that checks proof witnesses coming from external SAT and SMT solvers"
+description: """
+- a certified checker for proof witnesses coming from the SAT solver ZChaff and the SMT solvers veriT and CVC4. This checker increases the confidence in these tools by checking their answers a posteriori and allows to import new theroems proved by these solvers in Coq;
+- decision procedures through new tactics that discharge some Coq goals to ZChaff, veriT, CVC4, and their combination
+- abducts for goals that external solvers fail to prove, which represent possibly missing hypotheses that would allow them to prove the goal, using the cvc5 SMT solver."""
+url {
+  src: "https://github.com/smtcoq/smtcoq/archive/refs/tags/SMTCoq-2.2+8.19.tar.gz"
+  checksum: "sha512=fce92b7c22ff453055c69666980b1f285fd5a9819fb741b206cacf311d1762030d0c25e7235d7d56888da84ac00384ae760f1111321c82249c47f3ca3b9a88b8"
+}


### PR DESCRIPTION
This PR:
- adds opam files for SMTCoq-2.2, for Coq 8.13 to 8.19
- updates opam files for the development version.