### PR TITLE
Package coq-elpi.2.0.0.1

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.2.0.0.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.0.0.1/opam
@@ -25,7 +25,7 @@ tags: [
 homepage: "https://github.com/LPCIC/coq-elpi"
 bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
 depends: [
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.10.0"}
   "stdlib-shims"
   "elpi" {= "1.18.1"}
   "coq" {>= "8.18" & < "8.19~"}

--- a/released/packages/coq-elpi/coq-elpi.2.0.0.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.0.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Elpi extension language for Coq"
+description: """\
+Coq-elpi provides a Coq plugin that embeds ELPI.
+It also provides a way to embed Coq's terms into λProlog using
+the Higher-Order Abstract Syntax approach
+and a way to read terms back.  In addition to that it exports to ELPI a
+set of Coq's primitives, e.g. printing a message, accessing the
+environment of theorems and data types, defining a new constant and so on.
+For convenience it also provides a quotation and anti-quotation for Coq's
+syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
+numbers, or `{{A -> B}}` to the representation of a product by unfolding
+ the `->` notation. Finally it provides a way to define new vernacular commands
+and
+new tactics."""
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: "Enrico Tassi"
+license: "LGPL-2.1-or-later"
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:λProlog"
+  "keyword:higher order abstract syntax"
+  "logpath:elpi"
+]
+homepage: "https://github.com/LPCIC/coq-elpi"
+bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "stdlib-shims"
+  "elpi" {= "1.18.1"}
+  "coq" {>= "8.18" & < "8.19~"}
+  "dot-merlin-reader" {with-dev}
+  "ocaml-lsp-server" {with-dev}
+]
+build: [
+  [make "build" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN="]
+  [make "test" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"] {with-test}
+]
+install: [make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"]
+dev-repo: "git+https://github.com/LPCIC/coq-elpi"
+url {
+  src:
+    "https://github.com/LPCIC/coq-elpi/releases/download/v2.0.0.1/coq-elpi-2.0.0.1.tar.gz"
+  checksum: [
+    "md5=aecc0d0156ccf6144ac934a854ec8820"
+    "sha512=fd6e52f9a30cd5ad76c0ca8874079a35da40b44078a4b147cbc08bd6ca77fca5ff1621f8eb76a66b6a12a2f5bbc82e0306e673b5f1861ce3dcc8f2635f4ef45a"
+  ]
+}


### PR DESCRIPTION
### `coq-elpi.2.0.0.1`
Elpi extension language for Coq
Coq-elpi provides a Coq plugin that embeds ELPI.
It also provides a way to embed Coq's terms into λProlog using
the Higher-Order Abstract Syntax approach
and a way to read terms back.  In addition to that it exports to ELPI a
set of Coq's primitives, e.g. printing a message, accessing the
environment of theorems and data types, defining a new constant and so on.
For convenience it also provides a quotation and anti-quotation for Coq's
syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
numbers, or `{{A -> B}}` to the representation of a product by unfolding
 the `->` notation. Finally it provides a way to define new vernacular commands
and
new tactics.



---
* Homepage: https://github.com/LPCIC/coq-elpi
* Source repo: git+https://github.com/LPCIC/coq-elpi
* Bug tracker: https://github.com/LPCIC/coq-elpi/issues

---
:camel: Pull-request generated by opam-publish v2.0.3