### PR TITLE
Fix dependecy to elpi 1.18.1 for coq-elpi.2.0.1

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.2.0.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.0.1/opam
@@ -27,7 +27,7 @@ bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
 depends: [
   "ocaml" {>= "4.10.0"}
   "stdlib-shims"
-  "elpi" {>= "1.18.1" & < "1.18.2~"}
+  "elpi" {= "1.18.1"}
   "coq" {>= "8.19" & < "8.20~"}
   "dot-merlin-reader" {with-dev}
   "ocaml-lsp-server" {with-dev}


### PR DESCRIPTION
Without this building coq-elpi fails with: 
```
#=== ERROR while compiling coq-elpi.2.0.1 =====================================#
# context              2.1.5 | macos/arm64 | ocaml-option-flambda.1 ocaml-variants.4.14.1+options | file:///Users/rtetley/Development/STAMP/platform/opam/opam-coq-archive/released
# path                 ~/.opam/CP.2023.11.0~8.19~2023.11+beta1/.opam-switch/build/coq-elpi.2.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build COQBIN=/Users/rtetley/.opam/CP.2023.11.0~8.19~2023.11+beta1/bin/ ELPIDIR=/Users/rtetley/.opam/CP.2023.11.0~8.19~2023.11+beta1/lib/elpi OCAMLWARN=
# exit-code            2
# env-file             ~/.opam/log/coq-elpi-32292-786b49.env
# output-file          ~/.opam/log/coq-elpi-32292-786b49.out
### output ###
# Error: The implementation src/coq_elpi_builtins_synterp.ml
# [...]
#        is not compatible with type
#          clause =
#            string option * ([ `After | `Before ] * string) option *
#            API.Data.term
#        The second variant type does not allow tag(s) `Replace
#        File "src/coq_elpi_builtins_synterp.mli", line 57, characters 0-32:
#          Expected declaration
#        File "src/coq_elpi_builtins_synterp.ml", line 70, characters 4-10:
#          Actual declaration
# make[1]: *** [src/coq_elpi_builtins_synterp.cmo] Error 2
# make: *** [build-core] Error 2
```