### PR TITLE
Update coq-unimath.20231010

### DIFF
--- a/released/packages/coq-unimath/coq-unimath.20231010/opam
+++ b/released/packages/coq-unimath/coq-unimath.20231010/opam
@@ -9,7 +9,7 @@ build: [make "BUILD_COQ=no" "-j%{jobs}%"]
 install: [make "BUILD_COQ=no" "install"]
 depends: [
   "ocaml"
-  "coq" {>= "8.16.1"}
+  "coq" {(>= "8.16.1" & < "8.17~") | >= "8.18"}
 ]
 synopsis: "Library of Univalent Mathematics"
 url {


### PR DESCRIPTION
The bug seems to appear only with Coq 8.17, but the package seems fine again with 8.18!

Error: https://coq-bench.github.io/clean/Linux-x86_64-4.14.0-2.0.10/released/8.17.0/unimath/20231010.html