### PR TITLE
coq-compcert.3.13.1 works on Coq 8.19.0

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.13.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.13.1/opam
@@ -14,7 +14,7 @@ tags: [
 homepage: "http://compcert.inria.fr/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 depends: [
-  "coq" {>= "8.12.0" & < "8.19~"}
+  "coq" {>= "8.12.0" & < "8.20~"}
   "menhir" {>= "20190626" & != "dev"}
   "ocaml" {>= "4.05.0" & < "5~"}
   "coq-flocq" {>= "4.1.0" & < "5~"}


### PR DESCRIPTION
cc: @MSoegtropIMC @xavierleroy @rtetley 