### PR TITLE
Allow Coq 8.19.0 for coq-record-update 0.3.3

### DIFF
--- a/released/packages/coq-record-update/coq-record-update.0.3.3/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.3/opam
@@ -16,7 +16,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%" "NO_TEST=1"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.19~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.20~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
This PR backports https://github.com/tchajed/coq-record-update/pull/43 to 0.3.3.