### PR TITLE
Allow Coq 8.19 for coq-paco 4.2.0

### DIFF
--- a/released/packages/coq-paco/coq-paco.4.2.0/opam
+++ b/released/packages/coq-paco/coq-paco.4.2.0/opam
@@ -15,7 +15,7 @@ license: "BSD-3-Clause"
 build: [make "-C" "src" "all" "-j%{jobs}%"]
 install: [make "-C" "src" "-f" "Makefile.coq" "install"]
 depends: [
-  "coq" {>= "8.13" & < "8.19~"}
+  "coq" {>= "8.13" & < "8.20~"}
 ]
 tags: [
   "date:2023-03-13"


### PR DESCRIPTION
I tested locally that paco 4.2.0 compiles with Coq 8.19.0.