### PR TITLE
Release fiat crypto and dependencies

### DIFF
--- a/extra-dev/packages/coq-rewriter/coq-rewriter.dev/opam
+++ b/extra-dev/packages/coq-rewriter/coq-rewriter.dev/opam
@@ -12,6 +12,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
+  "conf-findutils" {build}
   "ocaml" {build & (arch = "x86_32" | arch = "x86_64" | >= "4.14.0")}
   "coq" {>= "8.17~"}
 ]

--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.7/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.7/opam
@@ -15,9 +15,9 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.16~"}
+  "coq" {>= "8.18~"}
   "coq-bedrock2" {= version}
-  "coq-riscv" {= "0.0.4"}
+  "coq-riscv" {= "0.0.5"}
   "zarith" {>= "1.11"}
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"

--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.7/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.7/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  # No reason to build compiler_ex since there's no install_compiler_ex target; the install_compiler target installs only compiler_noex
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "compiler_noex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.16~"}
+  "coq-bedrock2" {= version}
+  "coq-riscv" {= "0.0.4"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming (compiler part)"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  This package includes a verified compiler targeting RISC-V
+from this language.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: "sha512=42e264df702c65915635f3a3276d3c841de67b3999ebae9b8727dcaa94222f1832bb56b04025a2aa4eb752531e18dc7f2effe83c491d7d22e8da66ca17cbd182"
+}

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.7/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "bedrock2_ex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_bedrock2"]
+run-test: [
+  [make "-j%{jobs}%" "-C" "bedrock2" "EXTERNAL_DEPENDENCIES=1" "test"]
+]
+depends: [
+  "conf-findutils" {build}
+  "conf-python-3" {build & with-test}
+  "coq" {>= "8.16~"}
+  "coq-coqutil" {= "0.0.4"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  A verified compiler targeting RISC-V from this language
+exists in the coq-bedrock2-compiler package on opam.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: "sha512=42e264df702c65915635f3a3276d3c841de67b3999ebae9b8727dcaa94222f1832bb56b04025a2aa4eb752531e18dc7f2effe83c491d7d22e8da66ca17cbd182"
+}

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.7/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.7/opam
@@ -18,8 +18,8 @@ run-test: [
 depends: [
   "conf-findutils" {build}
   "conf-python-3" {build & with-test}
-  "coq" {>= "8.16~"}
-  "coq-coqutil" {= "0.0.4"}
+  "coq" {>= "8.18~"}
+  "coq-coqutil" {= "0.0.5"}
   "zarith" {>= "1.11"}
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"

--- a/released/packages/coq-coqutil/coq-coqutil.0.0.5/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.5/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.17~"}
 ]
 conflict-class: [
   "coq-coqutil"

--- a/released/packages/coq-coqutil/coq-coqutil.0.0.5/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+]
+conflict-class: [
+  "coq-coqutil"
+]
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+description: """
+### coqutil -- Various Coq Utilities
+
+Contents:
+* [Datatypes](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Datatypes): Some utilities for existing datatypes, and new datatypes.
+* [Decidable](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Decidable.v): `BoolSpec`-based decidability typeclasses. Allows one to write `if MyType_eqb a b then ... else ...` where `MyType_eqb a b` returns a `bool`, instead of writing `if MyType_eq_dec a b then ... else ...` where `MyType_eq_dec a b` returns a `sumbool`, while still getting `a = b` and `a <> b` as hypotheses (as opposed to `MyType_eqb a b = true` and `MyType_eqb a b = false`) after destructing the `if` (need to use [`destr`](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Tactics/destr.v) instead of `destruct`). So one gets the benefits of `Sumbool` without getting its disadvantage of having to carry around proof terms, which can cause a blow-up under reduction if one is not careful.
+* [Map](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Map): A typeclass based map library allowing one to abstract over the concrete implementation of maps. The implementations have to be extensional, which excludes certain efficient implementations, but simplifies proofs, because one can `replace mapA with mapB` if one can prove that `mapA` and `mapB` have the same contents. Comes with a [solver](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Map/Solver.v) which works reasonably fast on most map goals we have encountered so far.
+* [Tactics](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Tactics): A collection of useful general-purpose tactics.
+* [Word](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Word): Fixed width words for any width, in the same typeclass based style as the map library. Designed for the case where all words have the same (potentially abstract) bit width. Therefore, it does not provide functions to concatenate and split words, which is better addressed by [bbv](https://github.com/mit-plv/bbv/).
+* [Z](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Z): Utilities to work with the `Z` type from Coq's standard library, including a tactic to prove `Z` equalities by splitting the equality into equalities on bit index ranges, a tactic to make `lia` capable of reasoning about goals with division and modulo, and a tactic to simplify expressions containing nested occurrences of `mod`, and more misc utilities.
+* Various macros, notations, and desirable default settings.
+
+Each feature is intended to be as minimal and as independent of the other features as possible, so that users can pick just what they need.
+"""
+tags: ["logpath:coqutil"]
+url {
+  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.5.tar.gz"
+  checksum: "sha512=a79b484345f61a47d74200f66d803086983d733f797ff1b3fc91d93d5a483745090df9be0dfe27cf3072e272c3ce7ff3eaa7d19c13e343a8d342f91081bb82c6"
+}

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.1.2/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "coq" "standalone-ocaml"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build & >= "4.08~"}
+  "ocamlfind" {build}
+  "coq" {>= "8.16~"}
+  "coq-coqprime" {>= "1.2.0"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.9"}
+  "coq-rupicola" {= "0.0.8"}
+  "coq-bedrock2-compiler" {= "0.0.6"}
+]
+conflict-class: [
+  "coq-fiat-crypto"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis: "Cryptographic Primitive Code Generation by Fiat"
+description: """
+Coq code and proofs for a command-line binary that can synthesize proven-correct
+big-integer modular field arithmetic operations for cryptography.
+Target languages include C, Rust, Zig, Go, and bedrock2.
+"""
+tags: ["logpath:Crypto"]
+url {
+  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.1.2.tar.gz"
+  checksum: "sha512=98d1d9124236f402a35bfc0d87bc2f9dd10d5a69778c14762d43f97f5a4ce24ecb6b9e4d7ca68133cac0d1577cd7629cbf9670d98c298ecc1190bbbdaa277d42"
+}

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.1.2/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.1.2/opam
@@ -13,16 +13,20 @@ license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
   [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "coq" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+install: [
+  [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+  ["etc/test-run-fiat-crypto-silent.sh" "%{bin}%/fiat_crypto"] {with-test}
+  ["etc/test-run-fiat-crypto-silent.sh" "fiat_crypto"] {with-test}
+]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & >= "4.08~"}
   "ocamlfind" {build}
-  "coq" {>= "8.16~"}
+  "coq" {>= "8.18~"}
   "coq-coqprime" {>= "1.2.0"}
-  "coq-rewriter" {>= "0.0.6" & <= "0.0.9"}
-  "coq-rupicola" {= "0.0.8"}
-  "coq-bedrock2-compiler" {= "0.0.6"}
+  "coq-rewriter" {>= "0.0.6"}
+  "coq-rupicola" {= "0.0.9"}
+  "coq-bedrock2-compiler" {= "0.0.7"}
 ]
 conflict-class: [
   "coq-fiat-crypto"

--- a/released/packages/coq-rewriter/coq-rewriter.0.0.11/opam
+++ b/released/packages/coq-rewriter/coq-rewriter.0.0.11/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors: [
+  "Google Inc."
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rewriter"
+bug-reports: "https://github.com/mit-plv/rewriter/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build & (arch = "x86_32" | arch = "x86_64" | >= "4.14.0")}
+  "coq" {>= "8.15~"}
+]
+dev-repo: "git+https://github.com/mit-plv/rewriter.git"
+synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"
+tags: ["logpath:Rewriter"]
+url {
+  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.11.tar.gz"
+  checksum: "sha512=5cf77dbc74d6a585fddf7405c6d0024834b6d9749457bda764eac55ec69d06e4dcc88cca9ff84ef37074602c17bef526aa17eed8a7214d202c359a0311df529d"
+}

--- a/released/packages/coq-rewriter/coq-rewriter.0.0.11/opam
+++ b/released/packages/coq-rewriter/coq-rewriter.0.0.11/opam
@@ -14,7 +14,7 @@ install: [make "install"]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & (arch = "x86_32" | arch = "x86_64" | >= "4.14.0")}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.17~"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rewriter.git"
 synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"

--- a/released/packages/coq-riscv/coq-riscv.0.0.5/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.5/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/riscv-coq"
+bug-reports: "https://github.com/mit-plv/riscv-coq/issues"
+license: "BSD-3-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "coq" {>= "8.15~"}
+  "coq-coqutil" {>= "0.0.3" & <= "0.0.5"}
+  "coq-record-update" {>= "0.3.0"}
+]
+dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
+synopsis: "RISC-V Specification in Coq, somewhat experimental"
+tags: ["logpath:riscv"]
+url {
+  src: "https://github.com/mit-plv/riscv-coq/archive/refs/tags/v0.0.5.tar.gz"
+  checksum: "sha512=f5c7e0aec4401ff523a2abc36bde9e5db238cf8cae33b78e594faebf6fafdd06e914950cc4df38f12ad278c37242c75d4d7cc36d4bf218a3f0e24911bb3eeb64"
+}

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.9/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.9/opam
@@ -16,8 +16,8 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.16~"}
-  "coq-bedrock2" {= "0.0.6"}
+  "coq" {>= "8.18~"}
+  "coq-bedrock2" {= "0.0.7"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rupicola.git"
 synopsis: "Gallina to imperative code compilation, currently in design phase"

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.9/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: [
+  "Clément Pit-Claudel <clement.pitclaudel@live.com>"
+  "Jade Philipoom"
+  "Dustin Jamner"
+  "Andres Erbsen"
+  "Adam Chlipala"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rupicola"
+bug-reports: "https://github.com/mit-plv/rupicola/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.16~"}
+  "coq-bedrock2" {= "0.0.6"}
+]
+dev-repo: "git+https://github.com/mit-plv/rupicola.git"
+synopsis: "Gallina to imperative code compilation, currently in design phase"
+tags: ["logpath:Rupicola"]
+url {
+  src: "https://github.com/mit-plv/rupicola/archive/refs/tags/v0.0.9.tar.gz"
+  checksum: "sha512=f3e0285c12635bbc44fc01258997a6d703ecf7a0c91c89cf0feadef46347677afde97ce748c705ec14f79bbd1c63fba91033450d567b62ae2364b2799bbadb35"
+}


### PR DESCRIPTION
```bash
#!/usr/bin/env bash

pkg="$1"
oldver="$2"
newver="$3"

function usage() {
    printf "USAGE: %s PKG OLDVER NEWVER\n" "$0"
}

if [ -z "$pkg" ] || [ -z "$oldver" ] || [ -z "$newver" ]; then
    usage;
    exit 1;
fi

set -ex

cd "$(git rev-parse --show-toplevel)"
pwd
pushd "released/packages/coq-${pkg}"
oldopam="coq-${pkg}.${oldver}/opam"
newopam="coq-${pkg}.${newver}/opam"
mkdir -p "coq-${pkg}.${newver}"
cp -f "$oldopam" "$newopam"
git add "$newopam"
sed -i "s/${oldver}/${newver}/g" "$newopam"
url="$(grep -o '^\s*src: .*' "$newopam" | grep -o '"[^"]*"' | tr -d '"')"
wget "$url" -O "$newver.tar.gz"
sha512="$(sha512sum "$newver.tar.gz" | cut -d' ' -f1)"
sed -i 's/\(checksum:[^"]*"\)[^"]*\("\)/\1sha512='"${sha512}"'\2/g' "$newopam"
git diff "$newopam"
git add "$newopam"
```

```
./release-next.sh coqutil 0.0.4 0.0.5; ./release-next.sh riscv 0.0.4 0.0.5; ./release-next.sh bedrock2 0.0.6 0.0.7; ./release-next.sh bedrock2-compiler 0.0.6 0.0.7; ./release-next.sh rupicola 0.0.8 0.0.9; ./release-next.sh rewriter 0.0.10 0.0.11; ./release-next.sh fiat-crypto 0.0.24 0.1.2
```