### PR TITLE
GeoCoq 2.5.0

### DIFF
--- a/released/packages/coq-geocoq-algebraic/coq-geocoq-algebraic.2.5.0/opam
+++ b/released/packages/coq-geocoq-algebraic/coq-geocoq-algebraic.2.5.0/opam
@@ -29,6 +29,7 @@ tags: [
   "keyword:model"
   "keyword:counter-model"
   "keyword:Cartesian space"
+  "date:2024-03-24"
 ]
 authors: [
   "Pierre Boutry       <contact@pierre.boutry.fr>"
@@ -37,5 +38,6 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+  src: "https://github.com/GeoCoq/GeoCoq/archive/v2.5.0.tar.gz"
+  checksum: "md5=75609aa3fe8a0fc00cd99c96547775df"
 }

--- a/released/packages/coq-geocoq-algebraic/coq-geocoq-algebraic.2.5.0/opam
+++ b/released/packages/coq-geocoq-algebraic/coq-geocoq-algebraic.2.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This subpackage contains a model of Tarski's axioms and some counter-models."
+
+build:     [["./configure-algebraic.sh"]
+            [make "-j%{jobs}%"]]
+install:   [[make "install"]]
+depends:   [
+  "coq-geocoq-main"    { =  version             }
+  "coq-mathcomp-field" { >= "1.11.0" & < "2.0~" }
+]
+conflicts: ["coq-geocoq-pof" { != version } ]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:Euclidean geometry"
+  "keyword:hyperbolic geometry"
+  "keyword:foundations"
+  "keyword:Tarski"
+  "keyword:parallel postulates"
+  "keyword:model"
+  "keyword:counter-model"
+  "keyword:Cartesian space"
+]
+authors: [
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Cyril Cohen         <cyril.cohen@inria.fr>"
+  "Stéphane Kastenbaum <stephane.kastenbaum@gmail.com>"
+]
+
+url {
+  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+}

--- a/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.5.0/opam
+++ b/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.5.0/opam
@@ -25,6 +25,7 @@ tags: [
   "keyword:Euclid"
   "keyword:Elements"
   "keyword:parallel postulates"
+  "date:2024-03-24"
 ]
 authors: [
   "Michael Beeson      <profbeeson@gmail.com>"
@@ -36,5 +37,6 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+  src: "https://github.com/GeoCoq/GeoCoq/archive/v2.5.0.tar.gz"
+  checksum: "md5=75609aa3fe8a0fc00cd99c96547775df"
 }

--- a/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.5.0/opam
+++ b/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This subpackage contains the axioms."
+
+build:   [["./configure-axioms.sh"]
+          [make "-j%{jobs}%"]]
+install: [[make "install"]]
+depends: ["coq-geocoq-coinc" { = version }]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:neutral geometry"
+  "keyword:Euclidean geometry"
+  "keyword:foundations"
+  "keyword:Tarski"
+  "keyword:Hilbert"
+  "keyword:Euclid"
+  "keyword:Elements"
+  "keyword:parallel postulates"
+]
+authors: [
+  "Michael Beeson      <profbeeson@gmail.com>"
+  "Gabriel Braun       <gabriel.braun@unistra.fr>"
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Charly Gries        <charly.gries@etu.unistra.fr>"
+  "Julien Narboux      <narboux@unistra.fr>"
+  "Pascal Schreck      <schreck@unistra.fr>"
+]
+
+url {
+  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+}

--- a/released/packages/coq-geocoq-coinc/coq-geocoq-coinc.2.5.0/opam
+++ b/released/packages/coq-geocoq-coinc/coq-geocoq-coinc.2.5.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This subpackage contains some tactics to deal with incidence properties."
+
+build:   [["./configure-coinc.sh"]
+          [make "-j%{jobs}%"]]
+install: [[make "install"]]
+depends: ["coq" { >= "8.10" } ]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:automation"
+]
+authors: [
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Julien Narboux      <narboux@unistra.fr>"
+  "Pascal Schreck      <schreck@unistra.fr>"
+]
+
+url {
+  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+}

--- a/released/packages/coq-geocoq-coinc/coq-geocoq-coinc.2.5.0/opam
+++ b/released/packages/coq-geocoq-coinc/coq-geocoq-coinc.2.5.0/opam
@@ -18,6 +18,7 @@ tags: [
   "category:Mathematics/Geometry/General"
   "keyword:geometry"
   "keyword:automation"
+  "date:2024-03-24"
 ]
 authors: [
   "Pierre Boutry       <contact@pierre.boutry.fr>"
@@ -26,5 +27,6 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+  src: "https://github.com/GeoCoq/GeoCoq/archive/v2.5.0.tar.gz"
+  checksum: "md5=75609aa3fe8a0fc00cd99c96547775df"
 }

--- a/released/packages/coq-geocoq-elements/coq-geocoq-elements.2.5.0/opam
+++ b/released/packages/coq-geocoq-elements/coq-geocoq-elements.2.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This subpackage contains a formalization of Euclid's proofs from Book I of the Elements."
+
+build:   [["./configure-elements.sh"]
+          [make "-j%{jobs}%"]]
+install: [[make "install"]]
+depends: ["coq-geocoq-axioms" { = version }]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:neutral geometry"
+  "keyword:Euclidean geometry"
+  "keyword:foundations"
+  "keyword:Euclid"
+  "keyword:Elements"
+]
+authors: [
+  "Michael Beeson      <profbeeson@gmail.com>"
+  "Julien Narboux      <narboux@unistra.fr>"
+  "Freek Wiedijk       <freek@cs.ru.nl>"
+]
+
+url {
+  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+}

--- a/released/packages/coq-geocoq-elements/coq-geocoq-elements.2.5.0/opam
+++ b/released/packages/coq-geocoq-elements/coq-geocoq-elements.2.5.0/opam
@@ -22,6 +22,7 @@ tags: [
   "keyword:foundations"
   "keyword:Euclid"
   "keyword:Elements"
+  "date:2024-03-24"
 ]
 authors: [
   "Michael Beeson      <profbeeson@gmail.com>"
@@ -30,5 +31,6 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+  src: "https://github.com/GeoCoq/GeoCoq/archive/v2.5.0.tar.gz"
+  checksum: "md5=75609aa3fe8a0fc00cd99c96547775df"
 }

--- a/released/packages/coq-geocoq-main/coq-geocoq-main.2.5.0/opam
+++ b/released/packages/coq-geocoq-main/coq-geocoq-main.2.5.0/opam
@@ -31,6 +31,7 @@ tags: [
   "keyword:continuity"
   "keyword:ruler and compass"
   "keyword:parallel postulates"
+  "date:2024-03-24"
 ]
 authors: [
   "Gabriel Braun       <gabriel.braun@unistra.fr>"
@@ -41,5 +42,6 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+  src: "https://github.com/GeoCoq/GeoCoq/archive/v2.5.0.tar.gz"
+  checksum: "md5=75609aa3fe8a0fc00cd99c96547775df"
 }

--- a/released/packages/coq-geocoq-main/coq-geocoq-main.2.5.0/opam
+++ b/released/packages/coq-geocoq-main/coq-geocoq-main.2.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This subpackage contains the main developments from Hilbert's and Tarski's axiom systems."
+
+build:   [["./configure-main.sh"]
+          [make "-j%{jobs}%"]]
+install: [[make "install"]]
+depends: ["coq-geocoq-axioms" { = version }]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:neutral geometry"
+  "keyword:Euclidean geometry"
+  "keyword:foundations"
+  "keyword:Tarski"
+  "keyword:Hilbert"
+  "keyword:Euclid"
+  "keyword:Pappus"
+  "keyword:Desargues"
+  "keyword:arithmetization"
+  "keyword:Pythagoras"
+  "keyword:Thales' intercept theorem"
+  "keyword:continuity"
+  "keyword:ruler and compass"
+  "keyword:parallel postulates"
+]
+authors: [
+  "Gabriel Braun       <gabriel.braun@unistra.fr>"
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Charly Gries        <charly.gries@etu.unistra.fr>"
+  "Julien Narboux      <narboux@unistra.fr>"
+  "Pascal Schreck      <schreck@unistra.fr>"
+]
+
+url {
+  src: "git+https://github.com/GeoCoq/GeoCoq.git#361873afd7358905e78b2eaca0c7087eee6ebe24"
+}

--- a/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.5.0/opam
+++ b/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.5.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This is a virtual package that can be safely removed."
+
+depends:  ["coq-geocoq-algebraic" { = version }]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:Euclidean geometry"
+  "keyword:hyperbolic geometry"
+  "keyword:foundations"
+  "keyword:Tarski"
+  "keyword:parallel postulates"
+  "keyword:model"
+  "keyword:counter-model"
+  "keyword:Cartesian space"
+]
+authors: [
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Cyril Cohen         <cyril.cohen@inria.fr>"
+  "Stéphane Kastenbaum <stephane.kastenbaum@gmail.com>"
+]

--- a/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.5.0/opam
+++ b/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.5.0/opam
@@ -22,6 +22,7 @@ tags: [
   "keyword:model"
   "keyword:counter-model"
   "keyword:Cartesian space"
+  "date:2024-03-24"
 ]
 authors: [
   "Pierre Boutry       <contact@pierre.boutry.fr>"

--- a/released/packages/coq-geocoq/coq-geocoq.2.5.0/opam
+++ b/released/packages/coq-geocoq/coq-geocoq.2.5.0/opam
@@ -37,6 +37,7 @@ tags: [
   "keyword:counter-model"
   "keyword:Cartesian space"
   "keyword:automation"
+  "date:2024-03-24"
 ]
 authors: [
   "Michael Beeson      <profbeeson@gmail.com>"

--- a/released/packages/coq-geocoq/coq-geocoq.2.5.0/opam
+++ b/released/packages/coq-geocoq/coq-geocoq.2.5.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "Pierre Boutry <contact@pierre.boutry.fr>"
+
+homepage:     "http://geocoq.github.io/GeoCoq/"
+dev-repo:     "git+https://github.com/GeoCoq/GeoCoq.git"
+bug-reports:  "https://github.com/GeoCoq/GeoCoq/issues"
+license:      "LGPL-3.0-only"
+
+synopsis:     "A formalization of foundations of geometry in Coq"
+description:  "This package depends on all subpackages."
+
+depends: [
+  "coq-geocoq-algebraic" { = version }
+  "coq-geocoq-elements"  { = version }
+]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:neutral geometry"
+  "keyword:Euclidean geometry"
+  "keyword:hyperbolic geometry"
+  "keyword:foundations"
+  "keyword:Tarski"
+  "keyword:Hilbert"
+  "keyword:Euclid"
+  "keyword:Elements"
+  "keyword:Pappus"
+  "keyword:Desargues"
+  "keyword:arithmetization"
+  "keyword:Pythagoras"
+  "keyword:Thales' intercept theorem"
+  "keyword:continuity"
+  "keyword:ruler and compass"
+  "keyword:parallel postulates"
+  "keyword:model"
+  "keyword:counter-model"
+  "keyword:Cartesian space"
+  "keyword:automation"
+]
+authors: [
+  "Michael Beeson      <profbeeson@gmail.com>"
+  "Gabriel Braun       <gabriel.braun@unistra.fr>"
+  "Pierre Boutry       <contact@pierre.boutry.fr>"
+  "Cyril Cohen         <cyril.cohen@inria.fr>"
+  "Charly Gries        <charly.gries@etu.unistra.fr>"
+  "Stéphane Kastenbaum <stephane.kastenbaum@gmail.com>"
+  "Julien Narboux      <narboux@unistra.fr>"
+  "Pascal Schreck      <schreck@unistra.fr>"
+  "Freek Wiedijk       <freek@cs.ru.nl>"
+]


### PR DESCRIPTION
For the moment this is just a draft as I have not yet released a new version of GeoCoq. But I want to see if it will go through your CI. If it does I will merge the branch, update the [Changelog](https://github.com/GeoCoq/GeoCoq/blob/master/Changelog) and the [README](https://github.com/GeoCoq/GeoCoq/blob/master/README.md). Then, I will release GeoCoq 2.5.0 so that I can update the src of the packages to the released version and mark it as ready for review.

I also [renamed](https://opam.ocaml.org/doc/Tricks.html#How-to-rename-a-package) [coq-geocoq-pof](https://github.com/GeoCoq/opam-coq-archive/blob/4136fff50d2b959947d50578bd705470a996daa2/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.5.0/opam) to [coq-geocoq-algebraic](https://github.com/GeoCoq/opam-coq-archive/blob/4136fff50d2b959947d50578bd705470a996daa2/released/packages/coq-geocoq-algebraic/coq-geocoq-algebraic.2.5.0/opam).

On my side I tested it with the following versions of Coq and mathcomp.

```
coq                    8.10.0      Formal proof management system
coq-mathcomp-field     1.11.0      Mathematical Components Library on Fields
```

```
coq                    8.11.1      Formal proof management system
coq-mathcomp-field     1.11.0      Mathematical Components Library on Fields
```

```
coq                    8.12.0      Formal proof management system
coq-mathcomp-field     1.12.0      Mathematical Components Library on Fields
```

```
coq                    8.13.0      Formal proof management system
coq-mathcomp-field     1.13.0      Mathematical Components Library on Fields
```

```
coq                    8.14.0      Formal proof management system
coq-mathcomp-field     1.14.0      Mathematical Components Library on Fields
```

```
coq                    8.15.0      Formal proof management system
coq-mathcomp-field     1.15.0      Mathematical Components Library on Fields
```

```
coq                    8.16.0      Formal proof management system
coq-mathcomp-field     1.16.0      Mathematical Components Library on Fields
```

```
coq                    8.17.0      The Coq Proof Assistant
coq-mathcomp-field     1.17.0      Mathematical Components Library on Fields
```

```
coq                    8.18.0      The Coq Proof Assistant
coq-mathcomp-field     1.18.0      Mathematical Components Library on Fields
```

```
coq                    8.19.1      The Coq Proof Assistant
coq-mathcomp-field     1.19.0      Mathematical Components Library on Algebra
```