### PR TITLE
Create opam release of coq-vst.3.0beta1

### DIFF
--- a/released/packages/coq-vst/coq-vst.3.0beta1/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "William Mansky"
+  "Josiah Dodds"
+  "Qinxiang Cao"
+  "Aquinas Hobor"
+  "Gordon Stewart"
+  "Qinshi Wang"
+  "Sandrine Blazy"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Jean-Marie Madiot"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "BSD-2-Clause"
+
+build: [
+  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+]
+install: [
+  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+]
+run-test: [
+  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.17" & < "8.20~"}
+  "coq-compcert" {= "3.13.1"}
+  "coq-vst-zlist" {= "2.13"}
+  "coq-flocq" {>= "4.1.0"}
+  "coq-iris" {= "dev.2024-02-04.0.0771fa71"}
+]
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2024-04-10"
+]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta1/VST-3.0beta1.tar.gz"
+  checksum: "sha256=776a79efd83f5b345a2b511f7ac6c2224d1c90f843782ffaa3cf3e4ab8195537"
+}

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=1504a664f1620a1f1c318efa1ddde4bb0992518a8b3621238f88fbcd79bb94eb"
+  checksum: "sha256=98074b2e0335e3446341d6c93c61945281a74109ec865d2eee9434cf070c7f34"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -24,6 +24,7 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "BSD-2-Clause"
 
 build: [
+  [make "depend" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
 ]
 install: [

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=98074b2e0335e3446341d6c93c61945281a74109ec865d2eee9434cf070c7f34"
+  checksum: "sha256=559dfc6772597951d602e453874a8235450a0f55f9ef7d18a13ffa73b1fd8524"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -24,7 +24,6 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "BSD-2-Clause"
 
 build: [
-  [make "depend" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]
 ]
 install: [
@@ -45,9 +44,9 @@ tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
-  "date:2024-04-10"
+  "date:2024-04-12"
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=7887c56ea0ec8b722d1ff0a8471fdefc8a24f5ae6522bd3763da036691b7c1e7"
+  checksum: "sha256=1504a664f1620a1f1c318efa1ddde4bb0992518a8b3621238f88fbcd79bb94eb"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -34,11 +34,11 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.17" & < "8.20~"}
+  "coq" {>= "8.18" & < "8.20~"}
   "coq-compcert" {= "3.13.1"}
   "coq-vst-zlist" {= "2.13"}
   "coq-flocq" {>= "4.1.0"}
-  "coq-iris" {= "dev.2024-02-04.0.0771fa71"}
+  "coq-iris" {= "4.2.0"}
 ]
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"
@@ -47,6 +47,6 @@ tags: [
   "date:2024-04-10"
 ]
 url {
-  src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta1/VST-3.0beta1.tar.gz"
-  checksum: "sha256=776a79efd83f5b345a2b511f7ac6c2224d1c90f843782ffaa3cf3e4ab8195537"
+  src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
+  checksum: "sha256=7887c56ea0ec8b722d1ff0a8471fdefc8a24f5ae6522bd3763da036691b7c1e7"
 }


### PR DESCRIPTION
This is VST 3.0beta1.  

VST 3.x is "VST on Iris", a rebuild of VST's core logic in the generic Iris framework. This means that most of msl no longer exists, veric has been rebuilt as a more maintainable and extensible logic, and it is possible to freely use Iris theorems and tactics in VST proofs. The top-level guarantee is exactly the same as in VST 2.x: soundness w.r.t. the operational semantics of CompCert Clight.  See also: https://doi.org/10.1145/3632848

Key new features include:

1. Support for Iris typeclasses and Iris Proof Mode (IPM). Predicates can be proved Persistent, Absorbing, etc., and then automatically handled accordingly in IPM. At any entailment, you can use iIntros to enter Iris Proof Mode. For details on Iris Proof Mode, see the Iris documentation (https://gitlab.mpi-sws.org/iris/iris/-/blob/master/docs/proof_mode.md). It is also possible to rewrite with both entailments and equivalences, as an alternative to using derives_trans or sep_apply to modify part of a separation logic assertion.

2. Full support for Iris ghost state (rather than the "Iris-style ghost state" of previous versions). Any Iris resource algebra can be used as ghost state after adding a thin wrapper (see ora/theories/algebra/frac_auth.v and progs64/verif_incr_gen.v). Ghost state can be discarded at any time, while memory resources are still treated linearly.

3. A compatibility mode, available by importing VST.floyd.compat. This hides Iris-related boilerplate and restores the notation and lemmas of VST 2.x, so that existing proofs will largely work as is. There are a few incompatibilities; proofs that use ghost state or external state (e.g., I/O via ITrees) cannot use compat, and proofs that manually manipulate entailment clauses with sepcon_assoc and sepcon_comm may break (but they're more easily proved with IPM anyway). For a full list of known incompatibilities and advice on porting, see PORTING.md [hyperlink this file].

4.  Installation instructions: coq-vst.3.0+beta1   in the coq-released archive, or fetch the v3.0beta1 release from VST and build it in Coq 8.18-8.19 with CompCert 3.13.1 ...

5.  It is likely that VST 2.x will be supported only until 2025, perhaps up to VST 2.16, in parallel with releases of VST 3.x. Release 2.14 of VST, compatible with Coq 8.17-8.19 and CompCert 3.13.1, was recently released and will soon be available via the Coq Platform 2024 release for Coq 8.19.