### PR TITLE
configuration fix for coq-vst.3.0beta2

### DIFF
--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=7322c456bd308d28f26f0e36077ce286758d6d2db79cbe30628b6f9193213a65"
+  checksum: "sha256=3050363f1e956adf08355dd5f6439de8ebc519d4e518d0866abceb948c4a4d82"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=1347e64daf15bcb6e816e2cf98dbec5d58fec83206b560c95b58548e06c99a07"
+  checksum: "sha256=6a851da611faa0bbac9d0835e8622575db641be1ffaacef0a0f4aa3ac7c31893"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=559dfc6772597951d602e453874a8235450a0f55f9ef7d18a13ffa73b1fd8524"
+  checksum: "sha256=1347e64daf15bcb6e816e2cf98dbec5d58fec83206b560c95b58548e06c99a07"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=6a851da611faa0bbac9d0835e8622575db641be1ffaacef0a0f4aa3ac7c31893"
+  checksum: "sha256=7322c456bd308d28f26f0e36077ce286758d6d2db79cbe30628b6f9193213a65"
 }

--- a/released/packages/coq-vst/coq-vst.3.0beta2/opam
+++ b/released/packages/coq-vst/coq-vst.3.0beta2/opam
@@ -48,5 +48,5 @@ tags: [
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v3.0beta2/VST-3.0beta2.tar.gz"
-  checksum: "sha256=98074b2e0335e3446341d6c93c61945281a74109ec865d2eee9434cf070c7f34"
+  checksum: "sha256=559dfc6772597951d602e453874a8235450a0f55f9ef7d18a13ffa73b1fd8524"
 }


### PR DESCRIPTION
Oops.  In #3013 we had a configuration issue that didn't show up in the CI, because the CI for VST uses an internal CompCert but the installed one uses the platform CompCert.  This fixes that; please merge this P.R.