### PR TITLE
Package coq-finmatrix.1.0.0

### DIFF
--- a/released/packages/coq-finmatrix/coq-finmatrix.1.0.0/opam
+++ b/released/packages/coq-finmatrix/coq-finmatrix.1.0.0/opam
@@ -35,13 +35,13 @@ install: [
 ]
 
   url {
-  src: "https://github.com/zhengpushi/FinMatrix/archive/refs/tags/1.0.0.tar.gz"
-  checksum: "sha256=7936d8598dae88d573205459641128c276a6cf965cbaa96b4b10baa08e02277e"
+  src: "https://github.com/zhengpushi/FinMatrix/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: "sha256=0df32351777137cac4ee4380de2e93358298738d81842008ba32fe748d8acfa5"
 }
 
 tags: [
   "keyword:matrices"
   "category:Mathematics/Algebra"
-  "date:2024-04-25"
+  "date:2024-04-26"
   "logpath:FinMatrix"
 ]


### PR DESCRIPTION
**FinMatrix** is a formal matrix library in Coq, which we started from finite sets (over natural numbers), vector based on finite sets, and matrices based on vectors. 
This implementation differs from the [CoqMatrix](https://zhengpushi.github.io/projects/CoqMatrix/) project, which have various models. 
We have formalized many algebraic and geometric vector or matrix theories, especially including two inversion matrix algorithms:
* **minvGE**, an inversion method based on Gaussian Elimination;
* **minvAM**, an inversion technique utilizing the Adjoint Matrix method.
The main features of this library is:
* Support for directly evaluation in Coq, including for minvGE or minvAM.
* Extracted OCaml code is clear and readable (free of obfuscated `magic.obj` code)
* Support Leibniz equality of vectors or matrices
* Intrinsic support for nested vectors of high rank.
The HTML document and dependent-graph can be found in homepage: [FinMatrix](https://zhengpushi.github.io/projects/FinMatrix) .