### PR TITLE
Three updates related to coq-kruskal-...

### DIFF
--- a/released/packages/coq-friedman-tree/coq-friedman-tree.1.1/opam
+++ b/released/packages/coq-friedman-tree/coq-friedman-tree.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Implementation of Friedman's TREE function based on Kruskal's theorem"
+description: """
+   Friedman's TREE function is an extremely fast growing function that
+   plays a role in reverse mathematics, that is the classification of
+   mathematical theories w.r.t. what kind of theorems can be proved within
+   those theories or what kind of functions they can prove exist. 
+   See the README.md file for further description.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Friedman-TREE/"
+bug-reports: "https://github.com/DmxLarchey/Friedman-TREE/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Friedman-TREE/"
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-fan"      {>= "1.0"}
+  "coq-kruskal-theorems" {>= "1.0"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Friedman-TREE/releases/download/v1.1/Friedman-TREE.1.1.tar.gz"
+  checksum: [
+    "sha256=82671b63512fed00028ffeddecba433281bda1a477d2395124888fe5f893a677"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-05-23"
+  "logpath:FriedmanTREE"
+]
+
+

--- a/released/packages/coq-kruskal-higman/coq-kruskal-higman.1.1/opam
+++ b/released/packages/coq-kruskal-higman/coq-kruskal-higman.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Extending Coq library for manipulating Almost Full relations with Higman's lemma"
+description: """
+   This library formalizes additional tools for AF relations, eg quasi morphisms applied to Higman's lemma.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Higman/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Higman/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Higman/"
+
+build: [
+  [make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees" {>= "1.3"}
+  "coq-kruskal-finite" {>= "1.3"}
+  "coq-kruskal-almostfull" {>= "1.0"}
+  "coq-kruskal-fan" {>= "1.0"}
+]
+
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Higman/releases/download/1.1/Kruskal-Higman.1.1.tar.gz"
+  checksum: [
+    "sha256=569c368874aaa532fbc9699b86952721d3e9024a277e7a45b834f68de8db4ba2"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-05-23"
+  "logpath:KruskalHigmanProp"
+  "logpath:KruskalHigmanType"
+]
+

--- a/released/packages/coq-kruskal-veldman/coq-kruskal-veldman.1.1/opam
+++ b/released/packages/coq-kruskal-veldman/coq-kruskal-veldman.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Wim Veldman's proof of Higman's and Kruskal tree theorems"
+description: """
+   This library formalizes additional tools for AF relations, eg AF lexicographic induction 
+   and relational quasi morphisms applied to Wim Veldman's constructive proof of the tree theorem.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Veldman/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Veldman/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Veldman/"
+
+build: [
+  [make "-j%{jobs}%" "prop"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees"
+  "coq-kruskal-finite"
+  "coq-kruskal-almostfull"
+  "coq-kruskal-fan"    {>= "1.0"}
+  "coq-kruskal-higman" {>= "1.1"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Veldman/releases/download/v1.1/Kruskal-Veldman.1.1.tar.gz"
+  checksum: [
+    "sha256=6e7f250d3ca09c23e74d4aaaa1dbc22b60999194b04d67a2759a6b6ab5b44efe"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-05-23"
+  "logpath:KruskalVeldmanProp"
+  "logpath:KruskalVeldmanType"
+]
+


### PR DESCRIPTION
Updated `coq-friedman-tree` and `coq-kruskal-[higman,veldman]` to account for the creation of an independent [`coq-kruskal-fan`](https://github.com/DmxLarchey/Kruskal-Fan/tree/main), which was split between of `Kruskal-Higman` (for the [`FAN_theorem`](https://github.com/DmxLarchey/Kruskal-Fan/blob/2d383b007b139b2c52ba79ae27ea81cfe98561c3/theories/af/fan.v#L86)) and `Friedman-TREE` (for [`af_konig`](https://github.com/DmxLarchey/Kruskal-Fan/blob/2d383b007b139b2c52ba79ae27ea81cfe98561c3/theories/af/af_konig.v#L131)).