### PR TITLE
coq-unicoq.dev seems compatible only with coq.dev

### DIFF
--- a/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
+++ b/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.14"}
+  "coq" {= "dev"}
 ]
 synopsis: "An enhanced unification algorithm for Coq"
 tags: [


### PR DESCRIPTION
At least it does not compile with Coq 8.19.