### PR TITLE
fix(coq-metalib): require Coq 8.14

### DIFF
--- a/extra-dev/packages/coq-metalib/coq-metalib.dev/opam
+++ b/extra-dev/packages/coq-metalib/coq-metalib.dev/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "coq-metalib"
 version: "dev"
 synopsis: "Locally Nameless Metatheory Library"
 maintainer: "Yishuai Li <yishuai@cis.upenn.edu>"

--- a/extra-dev/packages/coq-metalib/coq-metalib.dev/opam
+++ b/extra-dev/packages/coq-metalib/coq-metalib.dev/opam
@@ -9,7 +9,7 @@ tags: "org:plclub"
 homepage: "https://github.com/plclub/metalib"
 bug-reports: "https://github.com/plclub/metalib/issues"
 depends: [
-  "coq" {>= "8.10"}
+  "coq" {>= "8.14"}
 ]
 build: [make "-j%{jobs}%" "-C" "Metalib"]
 install: [make "-C" "Metalib" "install"]


### PR DESCRIPTION
The letest version of coq-metalib [requires 8.14](https://github.com/liyishuai/metalib/actions/runs/7015658712). Although the [`opam`](https://github.com/plclub/metalib/blob/master/coq-metalib.opam) file in the original repository is updated, the maintainer does not appear to have synced this update to this repository.

Error message when trying to install coq-metalib with Coq 8.10:
```
λ ~/Workspace/ opam install coq-metalib 
The following actions will be performed:
  ∗ install coq-metalib dev

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved coq-metalib.dev  (no changes)
[ERROR] The compilation of coq-metalib.dev failed at "make -j7 -C Metalib".

#=== ERROR while compiling coq-metalib.dev ====================================#
# context     2.1.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | https://coq.inria.fr/opam/extra-dev#2024-06-11 09:25
# path        ~/.opam/with-coq-8.10/.opam-switch/build/coq-metalib.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j7 -C Metalib
# exit-code   2
# env-file    ~/.opam/log/coq-metalib-77702-290084.env
# output-file ~/.opam/log/coq-metalib-77702-290084.out
### output ###
# [...]
# Error: This command does not support this attribute: export.
# 
# make[2]: *** [CoqSrc.mk:658: CoqEqDec.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# File "./CoqFSetDecide.v", line 473, characters 4-141:
# Error: This command does not support this attribute: global.
# 
# make[2]: *** [CoqSrc.mk:658: CoqFSetDecide.vo] Error 1
# make[1]: *** [CoqSrc.mk:321: all] Error 2
# make[1]: Leaving directory '/home/skylee/.opam/with-coq-8.10/.opam-switch/build/coq-metalib.dev/Metalib'
# make: *** [Makefile:52: coq] Error 2
# make: Leaving directory '/home/skylee/.opam/with-coq-8.10/.opam-switch/build/coq-metalib.dev/Metalib'



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build coq-metalib dev
└─ 
╶─ No changes have been performed
```