### PR TITLE
Pi agm 1.2.8

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.6.1/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.6.1/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12" & < "8.13~" }
+  "coq" {>= "8.12" & < "8.17~" }
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/releases/download/v1.2.6/pi-agm-1.2.6.tgz"
-  checksum: "sha256=65f6f470c5942d04b0185c7d9350c6c32dcae1fb05112091f4696edc59e1ea79"
+  src: "https://github.com/ybertot/pi-agm/releases/download/v1.2.6.1/pi-agm-fix.1.2.6.tgz"
+  checksum: "sha256=450657c57d6b9d3d455212e367ac64070062e93cae837be1263acffe0cba68f9"
 }

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.6/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.6/opam
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/archive/v1.2.6.zip"
-  checksum: "sha256=f690dd8e464acafb4c14437a0ad09545a11f4ebd6771b05f4e7f74ca5c08a7ff"
+  src: "https://github.com/ybertot/pi-agm/releases/download/v1.2.6/pi-agm-1.2.6.tgz"
+  checksum: "sha256=65f6f470c5942d04b0185c7d9350c6c32dcae1fb05112091f4696edc59e1ea79"
 }

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.7/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.7/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12" & < "8.17~" }
+  "coq" {<= "8.17" & < "8.20~"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/archive/v1.2.6.zip"
-  checksum: "sha256=f690dd8e464acafb4c14437a0ad09545a11f4ebd6771b05f4e7f74ca5c08a7ff"
+  src: "https://github.com/ybertot/pi-agm/releases/download/1.2.7/pi-agm-1.2.7.tgz"
+  checksum: "sha256=8a7012b877848e41d2366100ed78c418ee749c46dc1965a41f79001735c7961b"
 }

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.7/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.7/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {<= "8.17" & < "8.20~"}
+  "coq" {>= "8.17" & < "8.20~"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/releases/download/1.2.7/pi-agm-1.2.8.tgz"
+  src: "https://github.com/ybertot/pi-agm/releases/download/1.2.8/pi-agm-1.2.8.tgz"
   checksum: "sha256=417bd20488f2480e5792b33cfea2a2d0211995f5dd726fec54302c9eb559b983"
 }

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12" & < "8.17~" }
+  "coq" {<= "8.19"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/archive/v1.2.6.zip"
-  checksum: "sha256=f690dd8e464acafb4c14437a0ad09545a11f4ebd6771b05f4e7f74ca5c08a7ff"
+  src: "https://github.com/ybertot/pi-agm/releases/download/1.2.7/pi-agm-1.2.8.tgz"
+  checksum: "sha256=417bd20488f2480e5792b33cfea2a2d0211995f5dd726fec54302c9eb559b983"
 }

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.8/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {<= "8.19"}
+  "coq" {>= "8.19"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]


### PR DESCRIPTION
Adding two versions of this package, and updating version 1.2.6

- version 1.2.6 was described as valid for every version of Coq since 8.12, it turns out it does not compile with coq 8.17
- version 1.2.7 removes the failures that appeared in 8.17 but has several deprecation warning in 8.19
- version 1.2.8 removes the deprecation warning that appeared in 8.19