### PR TITLE
Restore continuous integration.

### DIFF
--- a/core-dev/packages/coq-core/coq-core.8.19+rc1/opam
+++ b/core-dev/packages/coq-core/coq-core.8.19+rc1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.14"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.19.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.19.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.14"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}


### PR DESCRIPTION
Instead of downgrading Dune so as to be able to install the dev version of Coq, Opam prefers to install the 8.19.dev version of Coq, which in turn breaks because of "dune subst".

Example: https://github.com/coq/opam/pull/3051/checks?check_run_id=26435202620