### PR TITLE
Release coq-vellvm v1.0.20240627

### DIFF
--- a/released/packages/coq-vellvm/coq-vellvm.v1.0.20240627/opam
+++ b/released/packages/coq-vellvm/coq-vellvm.v1.0.20240627/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "stevez@cis.upenn.edu"
+synopsis: "Coq library implementing (executable) semantics for LLVM IR"
+
+homepage: "https://github.com/vellvm/vellvm"
+dev-repo: "git+https://github.com/vellvm/vellvm.git"
+bug-reports: "https://github.com/vellvm/vellvm/issues"
+authors: [
+  "Steve Zdancewic <stevez@cis.upenn.edu>"
+  "Yannick Zakowski <yannick.zakowski@inria.fr>"
+  "Calvin Beck <hobbes@seas.upenn.edu>"
+  "Irene Yoon <euisuny@cis.upenn.edu>"
+  "Gary (Hanxi) Chen <hanxic@seas.upenn.edu>"
+]
+license: "GPL-3.0-or-later"
+
+
+build: [make "-C" "src" "all" "-j%{jobs}%"]
+install: [make "-C" "src" "install"]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "cppo"
+  "dune" {>= "2.8"}
+  "menhir"
+  "qcheck"
+  "coq" {>= "8.19.0" & < "8.20~"}
+  "coq-ext-lib" {< "0.12.1"}
+  "coq-paco"
+  "coq-ceres"
+  "coq-flocq" {>= "4.1.1"}
+  "coq-mathcomp-ssreflect"
+  "coq-simple-io"
+  "coq-itree" {>= "5.1.2" & < "5.2~"}
+  "coq-quickchick" {>= "2.0.2" & < "2.0.3"}
+]
+
+tags: [
+  "date:2024-06-27"
+
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+
+  "keyword:semantics"
+  "keyword:interpreter"
+  "keyword:LLVM"
+
+  "logpath:Vellvm"
+]
+
+url {
+  src: "https://github.com/vellvm/vellvm/releases/download/v1.0.20240627/v1.0.20240627.tar.gz"
+  checksum: "sha256=8f1377ecc7f652004b6f98e0d4f4c3dd02ce53e4f840349e2191fa54d7089810"
+}


### PR DESCRIPTION
Updating vellvm to the following release:

https://github.com/vellvm/vellvm/releases/tag/v1.0.20240627

Minor bug fixes to the pretty printer. The gitlab CI is unlikely to succeed because of memory requirements.

This run of the CI corresponds to this release: https://github.com/vellvm/vellvm/actions/runs/9701150212