### PR TITLE
libhyps 2.0.8 compiles on Coq 8.20

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.2.0.8/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.2.0.8/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 
 depends: [
-  "coq" {(>= "8.11" & < "8.20~") | (= "dev")}
+  "coq" {(>= "8.11" & < "8.21~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Backport from nix