### PR TITLE
mathcomp-zify 1.3.0 compiles with Coq 8.20

### DIFF
--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.3.0+1.12+8.13/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.3.0+1.12+8.13/opam
@@ -15,7 +15,7 @@ by extending the zify tactic."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.13" & < "8.20~")}
+  "coq" {(>= "8.13" & < "8.21~")}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.20~")}
   "coq-mathcomp-algebra" 
 ]


### PR DESCRIPTION
Backport from nix