### PR TITLE
coq-mathcomp-finmap.2.1.0 works on Coq 8.20

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.1.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.1.0/opam
@@ -17,7 +17,7 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.16" & < "8.20~") | (= "dev") }
+  "coq" { (>= "8.16" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.0.0" & < "2.3~") | (= "dev") }
 ]
 


### PR DESCRIPTION
cc: @proux01 