### PR TITLE
coq-mathcomp-algebra-tactics.1.2.3 works on 8.20

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.3/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.3/opam
@@ -23,7 +23,7 @@ ring/field expressions before applying the proof procedures."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.20~"}
+  "coq" {>= "8.16" & < "8.21~"}
   "coq-mathcomp-ssreflect" {>= "2.0" & < "2.3~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}


### PR DESCRIPTION
cc: @proux01 