### PR TITLE
coq-mathcomp-tarjan.1.0.2 works on Coq 8.20

### DIFF
--- a/released/packages/coq-mathcomp-tarjan/coq-mathcomp-tarjan.1.0.2/opam
+++ b/released/packages/coq-mathcomp-tarjan/coq-mathcomp-tarjan.1.0.2/opam
@@ -16,7 +16,7 @@ sorting with extended guarantees for acyclic graphs."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.20~"}
+  "coq" {>= "8.16" & < "8.21~"}
   "coq-mathcomp-ssreflect" {>= "2.0"}
   "coq-mathcomp-fingroup" 
   "coq-hierarchy-builder" {>= "1.4.0"}


### PR DESCRIPTION
cc: @proux01 