### PR TITLE
Add bound coq < 8.21~ for coq-elpi 2.2.1

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.2.2.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "stdlib-shims"
   "elpi" {>= "1.18.2" & < "1.20.0~"}
-  "coq" {>= "8.19"}
+  "coq" {>= "8.19" & < "8.21~"}
   "ppx_optcomp"
   "ocaml-lsp-server" {dev}
   "odoc" {with-doc}


### PR DESCRIPTION
should stop it from being installed when coq = dev in the bench