### PR TITLE
Package coq-elpi.2.2.2

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.2.2.2/opam
+++ b/released/packages/coq-elpi/coq-elpi.2.2.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Elpi extension language for Coq"
+description:
+  "Coq-elpi provides a Coq plugin that embeds ELPI. It also provides a way to embed Coq's terms into λProlog using the Higher-Order Abstract Syntax approach and a way to read terms back. In addition to that it exports to ELPI a set of Coq's primitives, e.g. printing a message, accessing the environment of theorems and data types, defining a new constant and so on. For convenience it also provides a quotation and anti-quotation for Coq's syntax in λProlog. E.g., `{{nat}}` is expanded to the type name of natural numbers, or `{{A -> B}}` to the representation of a product by unfolding the `->` notation. Finally it provides a way to define new vernacular commands and new tactics."
+maintainer: ["Enrico Tassi <enrico.tassi@inria.fr>"]
+authors: ["Enrico Tassi <enrico.tassi@inria.fr>"]
+license: "LGPL-2.1-or-later"
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:λProlog"
+  "keyword:higher order abstract syntax"
+  "logpath:elpi"
+]
+homepage: "https://github.com/LPCIC/coq-elpi"
+bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
+depends: [
+  "dune" {>= "3.13"}
+  "ocaml" {>= "4.10.0"}
+  "stdlib-shims"
+  "elpi" {>= "1.18.2" & < "1.20.0~"}
+  "coq" {>= "8.19" & < "8.21"}
+  "ppx_optcomp"
+  "ocaml-lsp-server" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LPCIC/coq-elpi.git"
+url {
+  src:
+    "https://github.com/LPCIC/coq-elpi/releases/download/v2.2.2/coq-elpi-2.2.2.tar.gz"
+  checksum: [
+    "md5=bfd0deade133af2054e7bc056ef04c3b"
+    "sha512=bbabacec5d922941006af7e72fc10b4266fb4cc32d937a26b601be204de0868878a03a6271f475f002e8ca4d0b51245962c44c52231064d27972a7c089e3a57b"
+  ]
+}


### PR DESCRIPTION
### `coq-elpi.2.2.2`
Elpi extension language for Coq
Coq-elpi provides a Coq plugin that embeds ELPI. It also provides a way to embed Coq's terms into λProlog using the Higher-Order Abstract Syntax approach and a way to read terms back. In addition to that it exports to ELPI a set of Coq's primitives, e.g. printing a message, accessing the environment of theorems and data types, defining a new constant and so on. For convenience it also provides a quotation and anti-quotation for Coq's syntax in λProlog. E.g., `{{nat}}` is expanded to the type name of natural numbers, or `{{A -> B}}` to the representation of a product by unfolding the `->` notation. Finally it provides a way to define new vernacular commands and new tactics.



---
* Homepage: https://github.com/LPCIC/coq-elpi
* Source repo: git+https://github.com/LPCIC/coq-elpi.git
* Bug tracker: https://github.com/LPCIC/coq-elpi/issues

---
:camel: Pull-request generated by opam-publish v2.0.3