### PR TITLE
Switch the build method of coq-mathcomp-multinomials.dev from dune to coq_makefile

### DIFF
--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
@@ -5,12 +5,10 @@ bug-reports: "https://github.com/math-comp/multinomials/issues"
 dev-repo: "git+https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
-build: [
-  [ "dune" "build" "-p" name "-j" jobs ]
-]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 depends: [
   "coq"                    {>= "8.16"}
-  "dune"                   {>= "3.8"}
   "coq-mathcomp-ssreflect" {>= "2.0"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {>= "1.0"}


### PR DESCRIPTION
See math-comp/multinomials#90.