### PR TITLE
coq-mathcomp-multinomials.2.2.0 is incompatible with coq-elpi >= 2.2.1

### DIFF
--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.2.2.0/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.2.2.0/opam
@@ -10,6 +10,7 @@ build: [
 ]
 depends: [
   "coq"                    {(>= "8.16" & < "8.21~") | = "dev"}
+  "coq-elpi"               {< "2.2.1~"}
   "dune"                   {>= "3.8"}
   "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.3~") | = "dev"}
   "coq-mathcomp-algebra"


### PR DESCRIPTION
Apparently, the build of coq-mathcomp-multinomials.2.2.0 (using Dune) is incompatible with coq-elpi >= 2.2.1 (see #3104 and math-comp/multinomials#90).

We don't have the same issue in the older versions of multinomials since coq-mathcomp-multinomials < 2.2.0 is compatible only with Coq < 8.19 and coq-elpi >= 2.2.1 is compatible only with coq >= 8.19.