### PR TITLE
Verified extraction v0.9.2 for Coq 8.19

### DIFF
--- a/released/packages/coq-verified-extraction/coq-verified-extraction.0.9.2+8.19/opam
+++ b/released/packages/coq-verified-extraction/coq-verified-extraction.0.9.2+8.19/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Matthieu Sozeau <matthieu.sozeau@inria.fr"
+homepage: "https://github.com/yforster/coq-verified-extraction"
+dev-repo: "git+https://github.com/yforster/coq-verified-extraction"
+bug-reports: "https://github.com/yforster/coq-verified-extraction/issues"
+authors: [
+ "Yannick Forster"
+ "Matthieu Sozeau"
+ "Nicolas Tabareau"
+]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" { >= "4.13" }
+  "malfunction" { >= "0.6" }
+  "coq" {>= "8.19" & < "8.20~"}
+  "coq-ceres" { >= "0.4.1" }
+  "coq-equations" {= "1.3+8.19"}
+  "coq-metacoq-erasure" {>= "1.3.2+8.19" }
+  "coq-metacoq-erasure-plugin" {>= "1.3.2+8.19" }
+]
+
+synopsis: "A Verified Extraction from Gallina to OCaml, written in Gallina"
+url {
+  src: "https://github.com/yforster/coq-verified-extraction/releases/download/v0.9.2-8.19/coq-verified-extraction-0.9.2-8.19.tar.gz"
+  checksum: "sha512=22e3b0e5c5ad173dc8377578494050742f991cbd764be2f04afb69a6da191f23a2c79bbe58ab7dfc5d06eab3941dfc0ca09fbf22b463f6fa8c9db36bb1f84395"
+}


### PR DESCRIPTION
This includes a new pass that should allow to have a single ffi package for regular ocaml extraction and verified extraction to malfunction in the future.