### PR TITLE
coq-mathcomp-classical.1.2.0 (and analysis-1.2.0) works on Coq 8.20

### DIFF
--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.2.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.2.0/opam
@@ -14,7 +14,7 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
-  "coq" { (>= "8.18" & < "8.20~") | (= "dev") }
+  "coq" { (>= "8.18" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.1.0") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"


### PR DESCRIPTION
@affeldt-aist FYI.

It would help if you explicitly record Coq as a dependency in both `coq-mathcomp-classical` and `coq-mathcomp-analysis`. It turns out that `coq-mathcomp-classical.0.7.0` works fine in 8.20, but  `coq-mathcomp-analysis.0.7.0` does not (due to error on `:>` inside `Class`). I leave them both unchanged here.