### PR TITLE
coq-vcfloat.2.1.1 doesn't work with coq-interval.4.10.0 and later

### DIFF
--- a/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
+++ b/released/packages/coq-vcfloat/coq-vcfloat.2.1.1/opam
@@ -30,7 +30,7 @@ run-test: [
 depends: [
   "coq" {>= "8.16" & < "8.18~"}
   "coq-flocq" {>= "4.1.1" & < "5.0"}
-  "coq-interval" {>= "4.8.0"}
+  "coq-interval" {>= "4.8.0" & < "4.10~"}
   "coq-compcert" {>= "3.12"}
   "coq-bignums"
 ]


### PR DESCRIPTION
It turns out (checked locally) that VCFloat 2.1.1 neither works with Interval 4.10.0 nor 4.11.0.

cc: @JasonGross @andrew-appel 