### PR TITLE
coq-compcert.3.14, 3.13.1 work on Coq 8.20

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.13.1/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.13.1/opam
@@ -27,7 +27,7 @@ tags: [
 homepage: "https://compcert.org/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 depends: [
-  "coq" {>= "8.12.0" & < "8.20~"}
+  "coq" {>= "8.12.0" & < "8.21~"}
   "menhir" {>= "20190626" & != "dev"}
   "ocaml" {>= "4.05.0" & < "5~"}
   "coq-flocq" {>= "4.1.0" & < "5~"}

--- a/released/packages/coq-compcert/coq-compcert.3.13.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.13.1/opam
@@ -14,7 +14,7 @@ tags: [
 homepage: "http://compcert.inria.fr/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 depends: [
-  "coq" {>= "8.12.0" & < "8.20~"}
+  "coq" {>= "8.12.0" & < "8.21~"}
   "menhir" {>= "20190626" & != "dev"}
   "ocaml" {>= "4.05.0" & < "5~"}
   "coq-flocq" {>= "4.1.0" & < "5~"}

--- a/released/packages/coq-compcert/coq-compcert.3.14/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.14/opam
@@ -14,7 +14,7 @@ tags: [
 homepage: "https://compcert.org/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 depends: [
-  "coq" {>= "8.12.0" & < "8.20~"}
+  "coq" {>= "8.12.0" & < "8.21~"}
   "menhir" {>= "20190626" & != "dev"}
   "ocaml" {>= "4.05.0" & < "5~"}
   "coq-flocq" {>= "4.1.0" & < "5~"}


### PR DESCRIPTION
Tested on Coq 8.20+rc1, so the Coq release managers guarantee compatibility with soon-to-appear 8.20.0 (under reasonable assumptions). This enables us to test *reverse* dependencies of CompCert on 8.20.

cc: @xavierleroy @MSoegtropIMC 