### PR TITLE
coq-vst-zlist.2.13, coq-vst.2.14, coq-vst-lib.2.14, coq-vcfloat.2.2 work on Coq 8.20

### DIFF
--- a/released/packages/coq-vcfloat/coq-vcfloat.2.2/opam
+++ b/released/packages/coq-vcfloat/coq-vcfloat.2.2/opam
@@ -25,7 +25,7 @@ run-test: [
   [make "-C" "vcfloat" "-j%{jobs}%" "tests" "COQEXTRAFLAGS=-native-compiler ondemand" {coq-native:installed & coq-compcert:version < "3.14~"}]
 ]
 depends: [
-  "coq" {>= "8.19" & < "8.20~"}
+  "coq" {>= "8.19" & < "8.21~"}
   "coq-flocq" {>= "4.1.4" & < "5.0"}
   "coq-interval" {>= "4.10.0"}
   "coq-compcert" {>= "3.13"}

--- a/released/packages/coq-vst-lib/coq-vst-lib.2.14/opam
+++ b/released/packages/coq-vst-lib/coq-vst-lib.2.14/opam
@@ -22,11 +22,11 @@ run-test: [
   [ make "-C" "lib" "-j%{jobs}%" "test-only"]
 ]
 depends: [
-  "coq" {>= "8.17" & < "8.20~"}
+  "coq" {>= "8.17" & < "8.21~"}
   "coq-compcert" {>= "3.13"}
   "coq-flocq" {>= "4.1.0" & < "5.0"}
   "coq-vcfloat" {>= "2.2"}
-  "coq-vst" {>= "2.13"}
+  "coq-vst" {>= "2.13" & < "3~"}
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/releases/download/v2.14/VST-2.14.tar.gz"

--- a/released/packages/coq-vst-zlist/coq-vst-zlist.2.13/opam
+++ b/released/packages/coq-vst-zlist/coq-vst-zlist.2.13/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "-C" "zlist" "install"]
 depends: [
-  "coq" {>= "8.16.1" & < "8.20~"}
+  "coq" {>= "8.16.1" & < "8.21~"}
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/archive/refs/tags/v2.13.tar.gz"

--- a/released/packages/coq-vst/coq-vst.2.14/opam
+++ b/released/packages/coq-vst/coq-vst.2.14/opam
@@ -33,7 +33,7 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.17" & < "8.20~"}
+  "coq" {>= "8.17" & < "8.21~"}
   "coq-compcert" {= "3.13.1"}
   "coq-vst-zlist" {= "2.13"}
   "coq-flocq" {>= "4.1.0"}


### PR DESCRIPTION
ci-skip: coq-vst-zlist.2.13 coq-vst.2.14 coq-vst-lib.2.14

Tested on Coq 8.20+rc1, so the Coq release managers guarantee compatibility with soon-to-appear 8.20.0 (under reasonable assumptions). This enables us to test packages that depend on VST on 8.20.

cc: @andrew-appel @mansky1 