### PR TITLE
coq-relation-algebra.1.7.10 does not work on Coq 8.20

### DIFF
--- a/released/packages/coq-relation-algebra/coq-relation-algebra.1.7.10/opam
+++ b/released/packages/coq-relation-algebra/coq-relation-algebra.1.7.10/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/damien-pous/relation-algebra/issues"
 license: "LGPL-3.0-or-later"
 depends: [
   "ocaml"
-  "coq" {>= "8.18" }
+  "coq" {>= "8.18" & < "8.21"}
 ]
 depopts: [ "coq-mathcomp-ssreflect" "coq-aac-tactics" ]
 build: [


### PR DESCRIPTION
cc: @damien-pous 