### PR TITLE
coq-quickchick.2.0.3 doesn't work on Coq 8.20

### DIFF
--- a/released/packages/coq-quickchick/coq-quickchick.2.0.3/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.2.0.3/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "4.07"}
   "menhir" {build}
   "cppo" {build & >= "1.6.8"}
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.15~" & < "8.21"}
   "coq-ext-lib"
   "coq-mathcomp-ssreflect"
   "coq-simple-io"
@@ -34,7 +34,7 @@ depends: [
   "ocamlbuild"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
 ]
 dev-repo: "git+https://github.com/QuickChick/QuickChick.git"


### PR DESCRIPTION
Here's the error message on Coq 8.20+rc1:
```coq
File "./src/TacticsUtil.v", line 39, characters 0-1111:
Error:
Non exhaustive match. Values in this pattern are not matched:
Unsafe.String _
```

cc: @Lysxia 

