### PR TITLE
Fix the dependencies of coq-mathcomp-real-closed.2.0.1

### DIFF
--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.1/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.1/opam
@@ -17,8 +17,8 @@ order theory of real closed field, through quantifier elimination."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.21~"}
-  "coq-mathcomp-ssreflect" {>= "2.0.0"}
+  "coq" {>= "8.17" & < "8.21~"}
+  "coq-mathcomp-ssreflect" {>= "2.1.0"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-field"
   "coq-mathcomp-bigenough" {>= "1.0.0"}


### PR DESCRIPTION
coq-mathcomp-real-closed.2.0.1 doesn't compile with MC 2.0. I'm fixing its dependencies according to [the opam file](https://github.com/math-comp/real-closed/blob/2.0.1/coq-mathcomp-real-closed.opam) in the real-closed repo.