### PR TITLE
release MathComp-Analysis 1.3.1

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.3.1/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.3.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This repository contains an experimental library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "theories" "-j%{jobs}%"]
+install: [make "-C" "theories" "install"]
+depends: [
+  "coq" { (>= "8.18" & < "8.21~") | (= "dev") }
+  "coq-mathcomp-classical" { = version}
+  "coq-mathcomp-solvable" { (>= "2.0.0") | (= "dev") }
+  "coq-mathcomp-field"
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:analysis"
+  "keyword:extended real numbers"
+  "keyword:filter"
+  "keyword:Cantor"
+  "keyword:topology"
+  "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
+  "logpath:mathcomp.analysis"
+  "date:2024-08-09"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+url {
+  src: "https://github.com/math-comp/analysis/releases/download/1.3.1/analysis-1.3.1.tar.gz"
+  checksum: "sha512=b7383d5935aeda207589f80dc085aed91d0a2e420c8308895d151c8abeb9706e03cad4b6d55fd05a958724753fab16e086929f2372d7f88dbbaf141fbd863b67"
+}

--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.3.1/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.3.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for classical logic for mathematical components"
+description: """
+This repository contains a library for classical logic for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "classical" "-j%{jobs}%"]
+install: [make "-C" "classical" "install"]
+depends: [
+  "coq" { (>= "8.18" & < "8.21~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "2.1.0") | (= "dev") }
+  "coq-mathcomp-fingroup"
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-finmap" { (>= "2.0.0") | (= "dev") }
+  "coq-hierarchy-builder" { (>= "1.4.0") }
+]
+
+tags: [
+  "category:Mathematics/Classical Logic"
+  "keyword:classical"
+  "keyword:logic"
+  "keyword:sets"
+  "keyword:set theory"
+  "keyword:function"
+  "keyword:cardinal"
+  "logpath:mathcomp.classical"
+  "date:2024-08-09"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+url {
+  src: "https://github.com/math-comp/analysis/releases/download/1.3.1/analysis-1.3.1.tar.gz"
+  checksum: "sha512=b7383d5935aeda207589f80dc085aed91d0a2e420c8308895d151c8abeb9706e03cad4b6d55fd05a958724753fab16e086929f2372d7f88dbbaf141fbd863b67"
+}


### PR DESCRIPTION
This version should be preferred over 1.3.0 for compatibility with algebra-tactics.