### PR TITLE
add gaia 2.2 packages

### DIFF
--- a/released/packages/coq-gaia-numbers/coq-gaia-numbers.2.2/opam
+++ b/released/packages/coq-gaia-numbers/coq-gaia-numbers.2.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of the sets of numbers Z, Q, and R following Bourbaki's Elements of Mathematics in Coq"
+description: """
+Implementation of the sets of numbers Z, Q, and R following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq-mathcomp-algebra"
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-ordinals" {= version}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:integers"
+  "keyword:rational numbers"
+  "keyword:real numbers"  
+  "logpath:gaia.numbers"
+  "date:2024-07-24"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v2.2.tar.gz"
+  checksum: "sha512=e025071a0e1a3aa5b9bd484913ecda39e4448a34f8d22c8eb3f7e03ce4e65012c2169bc1ce8c4410727fa8a6a4a0debfe6c3772a77b162e0adbbd1acf5a36c2d"
+}

--- a/released/packages/coq-gaia-ordinals/coq-gaia-ordinals.2.2/opam
+++ b/released/packages/coq-gaia-ordinals/coq-gaia-ordinals.2.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation and properties of ordinals in Coq using Mathematical Components"
+description: """
+Implementation and properties of ordinals and cardinals in Coq using
+the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-schutte" {= version}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Logic/Set theory"
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordered sets"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinal numbers"
+  "keyword:cardinal numbers"
+  "logpath:gaia.ordinals"
+  "date:2024-07-24"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v2.2.tar.gz"
+  checksum: "sha512=e025071a0e1a3aa5b9bd484913ecda39e4448a34f8d22c8eb3f7e03ce4e65012c2169bc1ce8c4410727fa8a6a4a0debfe6c3772a77b162e0adbbd1acf5a36c2d"
+}

--- a/released/packages/coq-gaia-schutte/coq-gaia-schutte.2.2/opam
+++ b/released/packages/coq-gaia-schutte/coq-gaia-schutte.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of ordinals in Coq following Schütte and Ackermann"
+description: """
+Types for ordinal numbers in Coq using the Mathematical Components library,
+following the approaches of Schütte and Ackermann."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinal numbers"
+  "logpath:gaia.schutte"
+  "date:2024-07-24"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v2.2.tar.gz"
+  checksum: "sha512=e025071a0e1a3aa5b9bd484913ecda39e4448a34f8d22c8eb3f7e03ce4e65012c2169bc1ce8c4410727fa8a6a4a0debfe6c3772a77b162e0adbbd1acf5a36c2d"
+}

--- a/released/packages/coq-gaia-stern/coq-gaia-stern.2.2/opam
+++ b/released/packages/coq-gaia-stern/coq-gaia-stern.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Properties of Fibonacci numbers and the Stern diatomic sequence in Coq"
+description: """
+Properties of Fibonacci numbers and the Stern diatomic sequence in Coq using the
+Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq-mathcomp-algebra"
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:Stern-Brocot"
+  "keyword:fibonacci numbers"
+  "logpath:gaia.stern"
+  "date:2024-07-24"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v2.2.tar.gz"
+  checksum: "sha512=e025071a0e1a3aa5b9bd484913ecda39e4448a34f8d22c8eb3f7e03ce4e65012c2169bc1ce8c4410727fa8a6a4a0debfe6c3772a77b162e0adbbd1acf5a36c2d"
+}

--- a/released/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.2.2/opam
+++ b/released/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of the Theory of Sets from Bourbaki's Elements of Mathematics in Coq"
+description: """
+Implementation of the Theory of Sets following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "3.5"}
+  "coq" {>= "8.16"}
+  "coq-mathcomp-ssreflect" {>= "2.0"}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Logic/Set theory"
+  "keyword:Bourbaki"
+  "keyword:set theory"
+  "logpath:gaia.sets"
+  "date:2024-07-24"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+  "Carlos Simpson"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v2.2.tar.gz"
+  checksum: "sha512=e025071a0e1a3aa5b9bd484913ecda39e4448a34f8d22c8eb3f7e03ce4e65012c2169bc1ce8c4410727fa8a6a4a0debfe6c3772a77b162e0adbbd1acf5a36c2d"
+}


### PR DESCRIPTION
ci-skip: coq-gaia-theory-of-sets.2.2 coq-gaia-ordinals.2.2 coq-gaia-schutte.2.2

cc: @thery 