### PR TITLE
Kruskal Trees, Finite and Almostfull: split clean Makefile target

### DIFF
--- a/released/packages/coq-kruskal-almostfull/coq-kruskal-almostfull.1.1/opam
+++ b/released/packages/coq-kruskal-almostfull/coq-kruskal-almostfull.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Base Coq library for manipulating Almost Full relations"
+description: """
+   This library formalizes ground results about Almost Full relations (AF) in Coq 8.14+, up to Dickson's lemma.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-AlmostFull/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-AlmostFull/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-AlmostFull/"
+
+build: [
+  [ make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq" {>= "8.14" & < "8.20~"}
+  "coq-kruskal-trees" {>= "1.1"}
+  "coq-kruskal-finite" {>= "1.1"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-AlmostFull/releases/download/1.1/Kruskal-AlmostFull-1.1.tar.gz"
+  checksum: [ "sha256=9fc4e3f46c28731c75576431b3f2d406332b079dfba21a6a1b8f7d1a0eb4950c" ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-08-27"
+  "logpath:KruskalAfProp"
+  "logpath:KruskalAfType"
+
+]

--- a/released/packages/coq-kruskal-finite/coq-kruskal-finite.1.4/opam
+++ b/released/packages/coq-kruskal-finite/coq-kruskal-finite.1.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating finiteness, finite choice and decision as used in proof of Kruskal's tree theorem"
+description: """
+   Tools to facilitate proofs of finiteness (ie listability), finite choice principles
+   and finite decidability.
+"""
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"]
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Finite/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Finite/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Finite/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq" {>= "8.14" & < "8.20~"}
+  "coq-kruskal-trees" {>= "1.4"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Finite/releases/download/1.4/Kruskal-Finite-1.4.tar.gz"
+  checksum: [
+    "sha256=ad8ae37320e6fca0803b3ec1dfb2e959d260374702aaf4d9e7cd611efb5f7d0a"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-08-27"
+  "logpath:KruskalFinite"
+]

--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.4/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem"
+description: """
+   Several implementations for roses trees are proposed with proper induction principles. 
+   Sons of the root are collected into dependent vectors, vectors, lists, etc.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)" "Jerome Hugues (https://github.com/jjhugues)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Trees/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Trees/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Trees/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq" {>= "8.14" & < "8.20~"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Trees/releases/download/1.4/Kruskal-Trees-1.4.tar.gz"
+  checksum: [
+    "sha256=f28768e7b09bf6d94c8224a00f334d6b83e2c9a59371d8d091440c05856ee066"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2024-08-27"
+  "logpath:KruskalTrees"
+]
+


### PR DESCRIPTION
Thx to @joom for pointing out the issue with the `find` tool on MacOS `opam` installs, see issue https://github.com/DmxLarchey/Kruskal-AlmostFull/issues/4.