### PR TITLE
Package coq-ext-lib.0.12.2

### DIFF
--- a/released/packages/coq-ext-lib/coq-ext-lib.0.12.2/opam
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.12.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A library of Coq definitions, theorems, and tactics"
+description:
+  "A collection of theories and plugins that may be useful in other Coq developments."
+maintainer: "gmalecha@gmail.com"
+authors: "Gregory Malecha"
+license: "BSD-2-Clause"
+tags: "logpath:ExtLib"
+homepage: "https://github.com/coq-community/coq-ext-lib"
+doc: "https://coq-community.github.io/coq-ext-lib/"
+bug-reports: "https://github.com/coq-community/coq-ext-lib/issues"
+depends: [
+  "coq" {>= "8.9" & (< "8.10" | >= "8.11")}
+]
+build: [make "-j%{jobs}%" "theories"]
+run-test: [make "-j%{jobs}%" "examples"]
+install: [make "install"]
+dev-repo: "git+https://github.com/coq-community/coq-ext-lib.git"
+url {
+  src:
+    "https://github.com/coq-community/coq-ext-lib/archive/refs/tags/v0.12.2.tar.gz"
+  checksum: [
+    "md5=5ec0acf1cece75511ffa7dab5ed35e73"
+    "sha512=5e90195bb26d05bfa6c9c4e65d8285f802b6cf4ae22932ce73707f5f0d36ceea76f6cbf467ab6480570aeac66de520459fb4433ff3fa71bd9b1f003d5dc139d0"
+  ]
+}


### PR DESCRIPTION
### `coq-ext-lib.0.12.2`
A library of Coq definitions, theorems, and tactics
A collection of theories and plugins that may be useful in other Coq developments.



---
* Homepage: https://github.com/coq-community/coq-ext-lib
* Source repo: git+https://github.com/coq-community/coq-ext-lib.git
* Bug tracker: https://github.com/coq-community/coq-ext-lib/issues

---
:camel: Pull-request generated by opam-publish v2.4.0