### PR TITLE
coq-ollibs v2.0.6 & v2.0.7

### DIFF
--- a/released/packages/coq-ollibs/coq-ollibs.2.0.6/opam
+++ b/released/packages/coq-ollibs/coq-ollibs.2.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OL libraries"
+description: """
+  Add-ons for the Coq standard library
+"""
+
+homepage: "https://github.com/olaure01/ollibs"
+dev-repo: "git+https://github.com/olaure01/ollibs.git"
+bug-reports: "https://github.com/olaure01/ollibs/issues"
+doc: "https://github.com/olaure01/ollibs/blob/master/README.md"
+maintainer: "olivier.laurent@ens-lyon.fr"
+authors: [
+  "Olivier Laurent" "Christophe Lucas"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  "coq" { >= "8.19" & < "8.20~" }
+]
+
+build: [
+  ["./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src: "https://github.com/olaure01/ollibs/archive/v2.0.6.tar.gz"
+  checksum: "sha256=87fe8219581cf13ab0670fb012327b60495e04b5935b8b864d67db898dfa8cfc"
+}
+
+tags: [
+  "keyword:standard library"
+  "keyword:list"
+  "keyword:permutation"
+  "keyword:decidable equality"
+  "keyword:finite multisets"
+  "category:Miscellaneous/Coq Extensions"
+  "date:2024-09-15"
+  "logpath:OLlibs"
+]

--- a/released/packages/coq-ollibs/coq-ollibs.2.0.7/opam
+++ b/released/packages/coq-ollibs/coq-ollibs.2.0.7/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OL libraries"
+description: """
+  Add-ons for the Coq standard library
+"""
+
+homepage: "https://github.com/olaure01/ollibs"
+dev-repo: "git+https://github.com/olaure01/ollibs.git"
+bug-reports: "https://github.com/olaure01/ollibs/issues"
+doc: "https://github.com/olaure01/ollibs/blob/master/README.md"
+maintainer: "olivier.laurent@ens-lyon.fr"
+authors: [
+  "Olivier Laurent" "Christophe Lucas"
+]
+license: "LGPL-3.0-or-later"
+
+depends: [
+  "coq" { >= "8.20" & < "8.21~" }
+]
+
+build: [
+  ["./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src: "https://github.com/olaure01/ollibs/archive/v2.0.7.tar.gz"
+  checksum: "sha256=756abd893154fe79d0bed3aac9a78ab10ff06d4fe427ed89c0d31ff35368ea51"
+}
+
+tags: [
+  "keyword:standard library"
+  "keyword:list"
+  "keyword:permutation"
+  "keyword:decidable equality"
+  "keyword:finite multisets"
+  "category:Miscellaneous/Coq Extensions"
+  "date:2024-09-16"
+  "logpath:OLlibs"
+]


### PR DESCRIPTION
updated versions for coq 8.19 and 8.20