### PR TITLE
add ott.dev to extra-dev repo

### DIFF
--- a/extra-dev/packages/ott/ott.dev/opam
+++ b/extra-dev/packages/ott/ott.dev/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+authors: ["Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens"]
+license: "BSD-3-Clause"
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ocamlbuild" {with-test}
+  "ocamlfind" {build | with-test}
+  "ocamlgraph"
+  "pprint" {with-test}
+  "menhir" {>= "20151112" & with-test}
+]
+build: [
+  [make "world"] { ocaml:native }
+  [make "world.byt"] { !ocaml:native }
+  ["rm" "src/ott"] {os = "win32"}
+  ["cp" "src/ott.opt" "src/ott"] {os = "win32" & ocaml:native}
+  ["cp" "src/ott.byte" "src/ott"] {os = "win32" & !ocaml:native}
+  [make "ott.install"]
+]
+run-test: [
+  [make "-C" "tests/menhir_tests/test_if"]
+  [make "-C" "tests/menhir_tests/test10menhir"]
+  [make "-C" "tests/menhir_tests/test10menhir_with_aux_args"]
+  [make "-C" "tests/menhir_tests/test10menhir_with_aux_rules"]
+]
+dev-repo: "git+https://github.com/ott-lang/ott.git"
+synopsis: "A tool for writing definitions of programming languages and calculi"
+description: """
+Ott takes as input a definition of a language syntax and semantics, in a
+concise and readable ASCII notation that is close to what one would write in
+informal mathematics.  It generates output:
+- a LaTeX source file that defines commands to build a typeset version of the definition;
+- a Coq version of the definition;
+- a HOL version of the definition;
+- an Isabelle/HOL version of the definition;
+- a Lem version of the definition;
+- an OCaml version of the syntax of the definition.
+Additionally, it can be run as a filter, taking a
+LaTeX/Coq/Isabelle/HOL/Lem/OCaml source file
+with embedded (symbolic) terms of the defined language, parsing them and
+replacing them by typeset terms.
+"""
+
+url {
+  src: "git+https://github.com/ott-lang/ott.git#master"
+}


### PR DESCRIPTION
While `ott` is not a directly a Coq package (it just generates Coq code), it is part of the Coq Platform. To enable debugging/fixing build and runtime issues related to the Platform, I propose this dev package be added to `extra-dev`, as has been done for `menhir`, `gappa`, etc. I intend to keep the package up-to-date with the Ott GitHub repo package definition.

cc: @MSoegtropIMC 