### PR TITLE
release MathComp-Analysis 1.5.0

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
@@ -1,0 +1,71 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This repository contains an experimental library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "theories" "-j%{jobs}%"]
+install: [make "-C" "theories" "install"]
+depends: [
+  "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
+  "coq-mathcomp-classical" { = version}
+  "coq-mathcomp-solvable" { (>= "2.0.0") | (= "dev") }
+  "coq-mathcomp-field"
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:analysis"
+  "keyword:extended real numbers"
+  "keyword:filter"
+  "keyword:Cantor"
+  "keyword:topology"
+  "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
+  "logpath:mathcomp.analysis"
+  "date:2024-10-09"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+url {
+  src: "https://github.com/math-comp/analysis/releases/download/1.5.0/analysis-1.5.0.tar.gz"
+  checksum: "sha512=f3a63126b0d7ca6b9e8af162f580ffea4583c7b2c3aa3daba970785a558a32214f8b8f8446a80d073d9e4fe824c02f5fe85fdca2c92ae7a73392aca6177311d2"
+}
+

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
@@ -16,7 +16,7 @@ install: [make "-C" "theories" "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
   "coq-mathcomp-classical" { = version}
-  "coq-mathcomp-solvable" { (>= "2.0.0") | (= "dev") }
+  "coq-mathcomp-solvable" { (>= "2.0.0") }
   "coq-mathcomp-field"
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
 ]

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.5.0/opam
@@ -1,6 +1,3 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
-
 opam-version: "2.0"
 maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
 

--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.5.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.5.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for classical logic for mathematical components"
+description: """
+This repository contains a library for classical logic for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "classical" "-j%{jobs}%"]
+install: [make "-C" "classical" "install"]
+depends: [
+  "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "2.1.0") | (= "dev") }
+  "coq-mathcomp-fingroup"
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-finmap" { (>= "2.0.0") | (= "dev") }
+  "coq-hierarchy-builder" { (>= "1.4.0") }
+]
+
+tags: [
+  "category:Mathematics/Classical Logic"
+  "keyword:classical"
+  "keyword:logic"
+  "keyword:sets"
+  "keyword:set theory"
+  "keyword:function"
+  "keyword:cardinal"
+  "logpath:mathcomp.classical"
+  "date:2024-10-09"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+url {
+  src: "https://github.com/math-comp/analysis/releases/download/1.5.0/analysis-1.5.0.tar.gz"
+  checksum: "sha512=f3a63126b0d7ca6b9e8af162f580ffea4583c7b2c3aa3daba970785a558a32214f8b8f8446a80d073d9e4fe824c02f5fe85fdca2c92ae7a73392aca6177311d2"
+}
+


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical.1.5.0