### PR TITLE
Introduce tags for Inria GitLab CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,9 @@ before_script:
 
 .opam-build:
   stage: build
+  tags:
+    - ci.inria.fr
+    - medium
   script: |
     PR=${CI_COMMIT_REF_NAME##pr-};
     echo "Github PR number: $PR";
@@ -48,6 +51,9 @@ before_script:
 # Json
 json-data:
   stage: build
+  tags:
+    - ci.inria.fr
+    - medium
   variables:
     COMPILER: "4.11.2"
   script: |
@@ -66,6 +72,9 @@ json-data:
 # Lint
 opam-lint:
   stage: lint
+  tags:
+    - ci.inria.fr
+    - medium
   variables:
     COMPILER: "4.11.2"
   script:


### PR DESCRIPTION
Following an issue with having hit our quotas on GitLab.com, and by request of @mattam82 in https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs-.26-plugin-devs/topic/GitLab.2Ecom.20subscription.20.2F.20compute.20minutes.

This PR introduces the tags that are needed to run jobs on Inria GitLab CI (using the shared runners there).

This PR should be merged just after coq/bot#324 is merged and deployed.