### PR TITLE
Release for coq-wasm.2.0.1

### DIFF
--- a/released/packages/coq-wasm/coq-wasm.2.0.1/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.0.1/opam
@@ -39,7 +39,7 @@ build: [
 dev-repo: "git+https://github.com/WasmCert/WasmCert-Coq.git"
 url {
   src: "https://github.com/WasmCert/WasmCert-Coq/archive/refs/tags/v2.0.1.tar.gz"
-  checksum: "sha256=cda6689ee2dd3b25139abae0d82777d8d6bfe819ef1fae129071a9086d65b831"
+  checksum: "sha256=24e8d079324edb46f06e63662fbd99c61f167504b20316cd9922191db5d01f57"
 }
 tags: [
   "keyword:WebAssembly"

--- a/released/packages/coq-wasm/coq-wasm.2.0.1/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.0.1/opam
@@ -39,7 +39,7 @@ build: [
 dev-repo: "git+https://github.com/WasmCert/WasmCert-Coq.git"
 url {
   src: "https://github.com/WasmCert/WasmCert-Coq/archive/refs/tags/v2.0.1.tar.gz"
-  checksum: "sha256=af62a6b3beff4f7b690c742d114a1d3361061664e6295b50a868016928e88a27"
+  checksum: "sha256=3f46e16c8cdcddd9ca2f78f45dddfb1fa561461ca631e5216771fe5c51663114"
 }
 tags: [
   "keyword:WebAssembly"

--- a/released/packages/coq-wasm/coq-wasm.2.0.1/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.0.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "2.0.1"
 synopsis: "Wasm formalisation in Coq"
 description:
   "Wasm formalisation in Coq, following the AFP formalisation of Conrad Watt"
@@ -44,6 +43,6 @@ url {
 tags: [
   "keyword:WebAssembly"
   "category:Computer Science/Semantics and Compilation/Semantics"
-  "Date:2024-10-17"
+  "date:2024-10-17"
   "logpath:Wasm"
 ]

--- a/released/packages/coq-wasm/coq-wasm.2.0.1/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.0.1/opam
@@ -39,7 +39,7 @@ build: [
 dev-repo: "git+https://github.com/WasmCert/WasmCert-Coq.git"
 url {
   src: "https://github.com/WasmCert/WasmCert-Coq/archive/refs/tags/v2.0.1.tar.gz"
-  checksum: "sha256=3f46e16c8cdcddd9ca2f78f45dddfb1fa561461ca631e5216771fe5c51663114"
+  checksum: "sha256=cda6689ee2dd3b25139abae0d82777d8d6bfe819ef1fae129071a9086d65b831"
 }
 tags: [
   "keyword:WebAssembly"

--- a/released/packages/coq-wasm/coq-wasm.2.0.1/opam
+++ b/released/packages/coq-wasm/coq-wasm.2.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+version: "2.0.1"
+synopsis: "Wasm formalisation in Coq"
+description:
+  "Wasm formalisation in Coq, following the AFP formalisation of Conrad Watt"
+maintainer: ["Xiaojia Rao" "Martin Bodin"]
+authors: [
+  "Martin Bodin" "Philippa Gardner" "Jean Pichon" "Xiaojia Rao" "Conrad Watt"
+]
+license: "MIT"
+homepage: "https://github.com/WasmCert/WasmCert-Coq"
+bug-reports: "https://github.com/WasmCert/WasmCert-Coq/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "coq" {>= "8.19" & < "8.20~"}
+  "coq-compcert" {>= "3.11"}
+  "coq-ext-lib" {>= "0.11.8"}
+  "coq-mathcomp-ssreflect" {< "2.0.0~"}
+  "coq-parseque" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "linenoise" {>= "1.4.0"}
+  "mdx" {>= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/WasmCert/WasmCert-Coq.git"
+url {
+  src: "https://github.com/WasmCert/WasmCert-Coq/archive/refs/tags/v2.0.1.tar.gz"
+  checksum: "sha256=af62a6b3beff4f7b690c742d114a1d3361061664e6295b50a868016928e88a27"
+}
+tags: [
+  "keyword:WebAssembly"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "Date:2024-10-17"
+  "logpath:Wasm"
+]


### PR DESCRIPTION
A new version for coq-wasm that compiles with Coq 8.19.

Changelog: https://github.com/WasmCert/WasmCert-Coq/releases/tag/v2.0.1

~Upd: Trying to debug this atm, as our own CI [succeeds](https://github.com/WasmCert/WasmCert-Coq/actions/runs/11384884828) (using Coq-community's CI action).~