### PR TITLE
[extra-dev] Add coq-mathcomp-reals, coq-mathcomp-altreals, coq-mathcomp-reals-stdlib and coq-mathcomp-analysis-stdlib

### DIFF
--- a/extra-dev/packages/coq-mathcomp-altreals/coq-mathcomp-altreals.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-altreals/coq-mathcomp-altreals.dev/opam
@@ -6,34 +6,27 @@ dev-repo: "git+https://github.com/math-comp/analysis.git"
 bug-reports: "https://github.com/math-comp/analysis/issues"
 license: "CECILL-C"
 
-synopsis: "A library for classical logic for mathematical components"
+synopsis: "A library for alternative real numbers for mathematical components"
 description: """
-This repository contains a library for classical logic for
+This repository contains a library for alternative real numbers for
 the Coq proof-assistant and using the Mathematical Components library."""
 
-build: [make "-C" "classical" "-j%{jobs}%"]
-install: [make "-C" "classical" "install"]
+build: [make "-C" "altreals" "-j%{jobs}%"]
+install: [make "-C" "altreals" "install"]
 depends: [
-  "coq" { (>= "8.19") }
-  "coq-mathcomp-ssreflect" { (>= "2.1.0") }
-  "coq-mathcomp-fingroup"
-  "coq-mathcomp-algebra"
-  "coq-mathcomp-finmap" { (>= "2.0.0") }
-  "coq-hierarchy-builder" { (>= "1.4.0") }
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
 ]
 
 tags: [
-  "category:Mathematics/Logic/Classical logic"
-  "keyword:classical logic"
-  "keyword:logic"
-  "keyword:sets"
-  "keyword:set theory"
-  "keyword:function"
-  "keyword:cardinal"
-  "logpath:mathcomp.classical"
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.altreals"
 ]
 authors: [
   "Reynald Affeldt"
+  "Alessandro Bruni"
   "Yves Bertot"
   "Cyril Cohen"
   "Marie Kerjean"

--- a/extra-dev/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.dev/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This repository contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "analysis_stdlib" "-j%{jobs}%"]
+install: [make "-C" "analysis_stdlib" "install"]
+depends: [
+  "coq-mathcomp-analysis" { = version}
+  "coq-mathcomp-reals-stdlib"
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/math-comp/analysis.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
@@ -14,8 +14,8 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-C" "theories" "-j%{jobs}%"]
 install: [make "-C" "theories" "install"]
 depends: [
-  "coq-mathcomp-classical" { = version}
-  "coq-mathcomp-solvable" { (>= "1.13.0") }
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-solvable"
   "coq-mathcomp-field"
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
 ]
@@ -23,12 +23,31 @@ depends: [
 tags: [
   "category:Mathematics/Real Calculus and Topology"
   "keyword:analysis"
+  "keyword:extended real numbers"
+  "keyword:filter"
+  "keyword:Cantor"
   "keyword:topology"
   "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
   "logpath:mathcomp.analysis"
 ]
 authors: [
   "Reynald Affeldt"
+  "Alessandro Bruni"
   "Yves Bertot"
   "Cyril Cohen"
   "Marie Kerjean"

--- a/extra-dev/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.dev/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This repository contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "reals_stdlib" "-j%{jobs}%"]
+install: [make "-C" "reals_stdlib" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+  src: "git+https://github.com/math-comp/analysis.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-reals/coq-mathcomp-reals.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-reals/coq-mathcomp-reals.dev/opam
@@ -6,34 +6,26 @@ dev-repo: "git+https://github.com/math-comp/analysis.git"
 bug-reports: "https://github.com/math-comp/analysis/issues"
 license: "CECILL-C"
 
-synopsis: "A library for classical logic for mathematical components"
+synopsis: "A library for real numbers for mathematical components"
 description: """
-This repository contains a library for classical logic for
+This repository contains a library for real numbers for
 the Coq proof-assistant and using the Mathematical Components library."""
 
-build: [make "-C" "classical" "-j%{jobs}%"]
-install: [make "-C" "classical" "install"]
+build: [make "-C" "reals" "-j%{jobs}%"]
+install: [make "-C" "reals" "install"]
 depends: [
-  "coq" { (>= "8.19") }
-  "coq-mathcomp-ssreflect" { (>= "2.1.0") }
-  "coq-mathcomp-fingroup"
-  "coq-mathcomp-algebra"
-  "coq-mathcomp-finmap" { (>= "2.0.0") }
-  "coq-hierarchy-builder" { (>= "1.4.0") }
+  "coq-mathcomp-classical" { = version}
 ]
 
 tags: [
-  "category:Mathematics/Logic/Classical logic"
-  "keyword:classical logic"
-  "keyword:logic"
-  "keyword:sets"
-  "keyword:set theory"
-  "keyword:function"
-  "keyword:cardinal"
-  "logpath:mathcomp.classical"
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals"
 ]
 authors: [
   "Reynald Affeldt"
+  "Alessandro Bruni"
   "Yves Bertot"
   "Cyril Cohen"
   "Marie Kerjean"


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical.dev coq-mathcomp-reals.dev coq-mathcomp-reals-stdlib.dev coq-mathcomp-analysis.dev
