### PR TITLE
[extra-dev] Update coq-elpi.dev lower bound on ocaml

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/LPCIC/coq-elpi"
 bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
 depends: [
   "dune" {>= "3.13"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.10.0"}
   "stdlib-shims"
   "elpi" {>= "1.18.2" & < "1.20.0~"}
   "coq" {= "dev"}


### PR DESCRIPTION
Copied bound from coq-elpi.2.2.3

Cc @gares following the failure of https://gitlab.inria.fr/coq/opam/-/jobs/4906344 in https://github.com/coq/opam/pull/3192