### PR TITLE
Make ci-skip work without version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,6 @@ Pipeline" green button at <https://gitlab.com/coq/opam-coq-archive/pipelines>.
 This will then build only on runners without pre-set timeouts (the Coq Pyrolyse
 server). It may still time out if the build takes longer than the GitLab
 project's timeout setting (24 hours). To skip some packages the first PR
-message can contain a line such as `ci-skip: p1.v1 p2.v2` where `p1` and `p2` are package names, and `v1` and `v2` are versions.
+message can contain a line such as `ci-skip: p1.v1 p2 p3.v3 p4` where
+`p1`, `p2`, `p3` and `p4` are package names, and `v1` and `v3` are
+versions (when no versions are given, skip all versions).

--- a/scripts/opam-coq-install-remove
+++ b/scripts/opam-coq-install-remove
@@ -34,7 +34,7 @@ while [ ! -z "$1" ]; do
         PKG_NAME_VERSION=`basename "$PKG_VERSION_DIR"`
         PKG_VERSION=`echo $PKG_NAME_VERSION | cut -d . -f 2-`
         PKG_NAME=`echo $PKG_NAME_VERSION | cut -d . -f 1`
-        if [ ! -z "${SKIP[$PKG_NAME_VERSION]}" ]; then
+        if [ ! -z "${SKIP[$PKG_NAME_VERSION]}" -o ! -z "${SKIP[$PKG_NAME]}" ]; then
           echo Skip $1 due to user request
         else
           echo Testing $1


### PR DESCRIPTION
I tend to often forget version numbers in the `ci-skip` commands. This makes it optional (which is probably a common usecase since many PRs only update a single version).