### PR TITLE
release MathComp-Analysis 1.7.0

### DIFF
--- a/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.7.0/opam
+++ b/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.7.0/opam
@@ -41,5 +41,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }

--- a/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.7.0/opam
+++ b/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "analysis_stdlib" "-j%{jobs}%"]
+install: [make "-C" "analysis_stdlib" "install"]
+depends: [
+  "coq-mathcomp-analysis" { = version}
+  "coq-mathcomp-reals-stdlib"
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This package contains a library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "theories" "-j%{jobs}%"]
+install: [make "-C" "theories" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-solvable"
+  "coq-mathcomp-field"
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:analysis"
+  "keyword:Cantor"
+  "keyword:topology"
+  "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
+  "logpath:mathcomp.analysis"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
@@ -60,5 +60,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }

--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.7.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.7.0/opam
@@ -50,5 +50,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }

--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.7.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.7.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for classical logic for mathematical components"
+description: """
+This repository contains a library for classical logic for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "classical" "-j%{jobs}%"]
+install: [make "-C" "classical" "install"]
+depends: [
+  "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "2.1.0") }
+  "coq-mathcomp-fingroup"
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-finmap" { (>= "2.0.0") }
+  "coq-hierarchy-builder" { (>= "1.4.0") }
+]
+
+tags: [
+  "category:Mathematics/Logic/Classical logic"
+  "keyword:classical logic"
+  "keyword:logic"
+  "keyword:sets"
+  "keyword:set theory"
+  "keyword:function"
+  "keyword:cardinal"
+  "keyword:filter"
+  "logpath:mathcomp.classical"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.7.0/opam
+++ b/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for alternative real numbers for mathematical components"
+description: """
+This package contains an experiment along real numbers
+made at the beginning of the MathComp-Analysis library
+(which now offers the coq-mathcomp-reals package).
+
+Beware that this still contains a few Admitted."""
+
+build: [make "-C" "experimental_reals" "-j%{jobs}%"]
+install: [make "-C" "experimental_reals" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.experimental_reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.7.0/opam
+++ b/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.7.0/opam
@@ -44,5 +44,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }

--- a/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.7.0/opam
+++ b/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.7.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "reals_stdlib" "-j%{jobs}%"]
+install: [make "-C" "reals_stdlib" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.7.0/opam
+++ b/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.7.0/opam
@@ -40,5 +40,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }

--- a/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.7.0/opam
+++ b/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for real numbers for mathematical components"
+description: """
+This package contains a library for real numbers for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "reals" "-j%{jobs}%"]
+install: [make "-C" "reals" "install"]
+depends: [
+  "coq-mathcomp-classical" { = version}
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "keyword:extended real numbers"
+  "logpath:mathcomp.reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
+checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+}

--- a/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.7.0/opam
+++ b/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.7.0/opam
@@ -41,5 +41,5 @@ authors: [
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"
-checksum: "sha256=54c6db0f72a8302000bd28c3ec9b26c63f3c620282e3bd714c9c84bd8bafa861"
+checksum: "sha256=eb3183ea3138b083e43ef0ced0dbaa18ae2b43ab4f2d2608bc421939b4fb2c23"
 }


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical coq-mathcomp-reals coq-mathcomp-analysis coq-mathcomp-reals-stdlib