### PR TITLE
Add opam package for new version coq-unimath.20240923

### DIFF
--- a/released/packages/coq-unimath/coq-unimath.20240923/opam
+++ b/released/packages/coq-unimath/coq-unimath.20240923/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "The UniMath Development Team"
+homepage: "https://github.com/UniMath/UniMath"
+dev-repo: "git+https://github.com/UniMath/UniMath.git"
+bug-reports: "https://github.com/UniMath/UniMath/issues"
+license: "Similar to MIT license"
+authors: ["The UniMath Development Team"]
+build: [make "BUILD_COQ=no" "-j%{jobs}%"]
+install: [make "BUILD_COQ=no" "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.18"}
+]
+synopsis: "Library of Univalent Mathematics"
+url {
+  src: "https://github.com/UniMath/UniMath/archive/refs/tags/v20240923.tar.gz"
+  checksum: "sha512=ffb905217bc6426d6ad00168959961f560a05c040b10de0145ef27e1d93e9ab9ef60f7f5127fc8b9e0b04ad99608b452dbf261bc34072ee4f47ef6b6951bbc47"
+}

--- a/released/packages/coq-unimath/coq-unimath.20240923/opam
+++ b/released/packages/coq-unimath/coq-unimath.20240923/opam
@@ -9,7 +9,7 @@ build: [make "BUILD_COQ=no" "-j%{jobs}%"]
 install: [make "BUILD_COQ=no" "install"]
 depends: [
   "ocaml"
-  "coq" {>= "8.18"}
+  "coq" {>= "8.19"}
 ]
 synopsis: "Library of Univalent Mathematics"
 url {


### PR DESCRIPTION
I didn't test the Coq lower bound - this is taken from the previous package.

I tested that this works with Coq 8.20.0.

@benediktahrens : if you have evidence on the Coq lower bound, please let me know. Otherwise I would suggest to keep it like this until someone fonds out that it does not work.

I guess CI will time out (not sure).