### PR TITLE
Coq dev/rc packages: remove outdated restriction to dune < 3.14

### DIFF
--- a/core-dev/packages/coq-core/coq-core.8.19+rc1/opam
+++ b/core-dev/packages/coq-core/coq-core.8.19+rc1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9" & < "3.14"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.19.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.19.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9" & < "3.14"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.20+rc1/opam
+++ b/core-dev/packages/coq-core/coq-core.8.20+rc1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6.1" & < "3.14"}
+  "dune" {>= "3.6.1"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.20.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.20.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6.1" & < "3.14"}
+  "dune" {>= "3.6.1"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9" & < "3.14"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}


### PR DESCRIPTION
This PR removes outdated restrictions to dune - none of the release Coq packages still has these so there is no good reason for keeping them in the dev packages.

There are known versions of dune to not work - one could exclude these, but this is not done in the Coq release packages either.