### PR TITLE
Add mathcomp bound on ssprove packages

### DIFF
--- a/released/packages/coq-ssprove/coq-ssprove.0.2.1/opam
+++ b/released/packages/coq-ssprove/coq-ssprove.0.2.1/opam
@@ -9,8 +9,8 @@ license: "MIT"
 depends: [
   "coq" {(>= "8.18" & < "8.20~")}
   "coq-equations" {(>= "1.3+8.18")}
-  "coq-mathcomp-ssreflect" {(>= "2.1.0")}
-  "coq-mathcomp-analysis" {>= "1.0.0"}
+  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.3~")}
+  "coq-mathcomp-analysis" {>= "1.0.0" & < "1.6~"}
   "coq-extructures" {(>= "0.4.0" & < "dev")}
   "coq-deriving" {(>= "0.2.0" & < "dev")}
 ]

--- a/released/packages/coq-ssprove/coq-ssprove.0.2.2/opam
+++ b/released/packages/coq-ssprove/coq-ssprove.0.2.2/opam
@@ -9,7 +9,7 @@ license: "MIT"
 depends: [
   "coq" {(>= "8.18" & < "8.21~")}
   "coq-equations" {(>= "1.3+8.18")}
-  "coq-mathcomp-ssreflect" {(>= "2.1.0")}
+  "coq-mathcomp-ssreflect" {(>= "2.1.0" & < "2.3~")}
   ("coq-mathcomp-analysis" {>= "1.0.0" & < "1.7.0"} | "coq-mathcomp-analysis" {>= "1.7.0"} & "coq-mathcomp-experimental-reals" {>= "1.7.0"})
   "coq-extructures" {(>= "0.4.0" & < "dev")}
   "coq-deriving" {(>= "0.2.0" & < "dev")}


### PR DESCRIPTION
SSProve 0.2.1 and 0.2.2 are not compatible with mathcomp 2.3.0