### PR TITLE
Relax versions restirctions of coq-mathcomp-algebra-tactics.1.2.3

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.3/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.2.3/opam
@@ -24,7 +24,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.16" & < "8.21~"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.3~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.4~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-zify" {>= "1.5.0"}
   "coq-elpi" {>= "1.15.0" & != "1.17.0"}


### PR DESCRIPTION
Tested locally to work.

I did not create a new version since this does not change anything on configurations where it did work before.