### PR TITLE
Relax version restrictions of coq-mathcomp-word.3.2

### DIFF
--- a/released/packages/coq-mathcomp-word/coq-mathcomp-word.3.2/opam
+++ b/released/packages/coq-mathcomp-word/coq-mathcomp-word.3.2/opam
@@ -12,7 +12,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.8"}
   "coq" {>= "8.16"}
-  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.3~"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.4~"}
   "coq-mathcomp-algebra"
 ]
 tags: [


### PR DESCRIPTION
Tested to work locally.

I did not create a new version since this does not change anything on configurations where it did work before.