### PR TITLE
ITree Extra 5.2.0 upper bound on Paco

### DIFF
--- a/released/packages/coq-itree-extra/coq-itree-extra.5.2.0/opam
+++ b/released/packages/coq-itree-extra/coq-itree-extra.5.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "3.14"}
   "coq"
   "coq-ext-lib" {>= "0.11.1"}
-  "coq-paco"
+  "coq-paco" {<= "4.2.0"}
   "coq-itree" {>= "5.1.0"}
 ]
 tags: [


### PR DESCRIPTION
- [x] DeepSpec/InteractionTrees#271

Failure with 4.2.1: https://github.com/coq-community/coq-ext-lib/actions/runs/12113974426/job/33769777446?pr=150#step:4:1365