### PR TITLE
Package coq-hierarchy-builder.1.8.0

### DIFF
--- a/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.8.0/opam
+++ b/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.8.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "High level commands to declare and evolve a hierarchy based on packed classes"
+description: """\
+Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
+hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
+and abbreviation that let the hierarchy developer describe an actual interface for their library.
+Behind that interface the developer can provide appropriate code to ensure retro compatibility."""
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: ["Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi"]
+license: "MIT"
+tags: "logpath:HB"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+depends: [
+  "coq-elpi" {(>= "2.0") | = "dev"}
+]
+conflicts: ["coq-hierarchy-builder-shim"]
+build: [
+  [make "build"]
+  [make "test-suite"] {with-test}
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+url {
+  src:
+    "https://github.com/math-comp/hierarchy-builder/releases/download/v1.8.0/hierarchy-builder-1.8.0.tar.gz"
+  checksum: [
+    "md5=3635ba1739c95d2635a0822fb52e2fba"
+    "sha512=f728bbc3c968b83802990d9dc4ff2a98af0a4c240b621cc420ebc60f9d0833817504f89df99d8fc166030c930ad032faf7007beda183c4c4d436d4cd7e27b3b5"
+  ]
+}


### PR DESCRIPTION
### `coq-hierarchy-builder.1.8.0`
High level commands to declare and evolve a hierarchy based on packed classes
Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
and abbreviation that let the hierarchy developer describe an actual interface for their library.
Behind that interface the developer can provide appropriate code to ensure retro compatibility.



---
* Homepage: https://github.com/math-comp/hierarchy-builder
* Source repo: git+https://github.com/math-comp/hierarchy-builder
* Bug tracker: https://github.com/math-comp/hierarchy-builder/issues

---
:camel: Pull-request generated by opam-publish v2.0.3