### PR TITLE
coq-coqeal.2.0.2 is not compatible with MathComp 2.3.0

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.2.0.2/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.2.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "coq-bignums" 
   "coq-paramcoq" {>= "1.1.3"}
   "coq-hierarchy-builder" {>= "1.4.0"}
-  "coq-mathcomp-ssreflect" {>= "2.0"}
+  "coq-mathcomp-ssreflect" {>= "2.0" & < "2.3"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-multinomials" {>= "2.0"}
   "coq-mathcomp-real-closed" {>= "2.0"}


### PR DESCRIPTION
@proux01 this is the error I get:
```
File "./refinements/boolF2.v", line 48, characters 3-35:
Error: The LHS of GRing.mulr0n
    (_ *+ 0)
does not match any subterm of the goal
```
So a new release is required. But all deps are there, see #3256 #3255 