### PR TITLE
avoid-version for coq-mathcomp-analysis.1.7.0 due to path.vo conflict

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.7.0/opam
@@ -57,6 +57,7 @@ authors: [
   "Pierre-Yves Strub"
   "Laurent Théry"
 ]
+flags: avoid-version # path.vo conflict with coq-mathcomp-ssreflect
 
 url {
 src: "https://github.com/math-comp/analysis/archive/1.7.0.tar.gz"


### PR DESCRIPTION
cc: @affeldt-aist @MSoegtropIMC 

This ensures coq-mathcomp-analysis.1.7.0 is only installed when explicitly asked for.