### PR TITLE
coq-fcsl-pcm.2.0.0 doesn't support coq-hierarchy-builder.1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install OCaml
-        uses: avsm/setup-ocaml@v2
+        uses: avsm/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.1
+          ocaml-compiler: 4.14.2
 
       - name: Build index
         run: |

--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.2.0.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.2.0.0/opam
@@ -23,6 +23,7 @@ install: [make "install"]
 depends: [
   "coq" { (>= "8.19" & < "8.21~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.2.0" & < "2.4~") | (= "dev") }
+  "coq-hierarchy-builder" { < "1.8" }
   "coq-mathcomp-algebra" 
 ]
 


### PR DESCRIPTION
Here is the error:
```
File "./pcm/pcm.v", line 429, characters 0-76:
Error:
HB: choice.hasChoice.axioms_ is not a factory or its library (mathcomp.ssreflect.choice) was not correctly imported
```
@aleksnanevski it's a good idea to record the dependency on HB in the meta/opam file in the fcsl-pcm repo.