### PR TITLE
coq-fcsl-pcm.dev depends on coq-hierarchy-builder

### DIFF
--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
@@ -11,6 +11,7 @@ install: [ make "install" ]
 depends: [
   "coq" {>= "8.19"}
   "coq-mathcomp-ssreflect" {>= "2.2.0"}
+  "coq-hierarchy-builder" {>= "1.7.0"}
   "coq-mathcomp-algebra"
 ]
 tags: [


### PR DESCRIPTION
cc: @aleksnanevski 