### PR TITLE
workaround for what appears to be opam admin check problem

### DIFF
--- a/scripts/generate-opam-indexes
+++ b/scripts/generate-opam-indexes
@@ -8,6 +8,7 @@ OPAMCHECKOPTS=--cycles
 
 for repo in "$@"; do
   cd "$repo"
-  opam admin check $OPAMCHECKOPTS && opam admin make
+  #opam admin check $OPAMCHECKOPTS && opam admin make
+  opam admin make
   cd ..
 done


### PR DESCRIPTION
- setup-ocaml@v2 no longer works
- setup-ocaml@v3 gives opam 2.3.0 which appears to have buggy/non-functional `opam admin check`
- broken `opam admin check` breaks generation of opam repo indexes for deployment
- workaround: disable use of `opam admin check` for now