### PR TITLE
[core-dev] Rename coq-stdlib -> rocq-stdlib

### DIFF
--- a/core-dev/packages/rocq-stdlib/rocq-stdlib.dev/opam
+++ b/core-dev/packages/rocq-stdlib/rocq-stdlib.dev/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
-synopsis: "Compatibility metapackage for Coq Stdlib library after the Rocq renaming"
+synopsis: "The Rocq Proof Assistant -- Standard Library"
 description: """
-Coq is a formal proof management system. It provides
+Rocq is a formal proof management system. It provides
 a formal language to write mathematical definitions, executable
 algorithms and theorems together with an environment for
 semi-interactive development of machine-checked proofs.
@@ -12,18 +12,18 @@ project, or the Bedrock verified low-level programming library), the
 formalization of mathematics (e.g. the full formalization of the
 Feit-Thompson theorem or homotopy type theory) and teaching.
 
-This package includes the Coq Standard Library, that is to say, the
+This package includes the Rocq Standard Library, that is to say, the
 set of modules usually bound to the Stdlib.* namespace."""
-maintainer: ["The Coq standard library development team"]
-authors: ["The Coq development team, INRIA, CNRS, and contributors"]
+maintainer: ["The Rocq standard library development team"]
+authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
 license: "LGPL-2.1-only"
 homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {>= "3.8"}
-  "coq-core"
-  "rocq-stdlib" {= version}
+  "rocq-runtime"
+  "rocq-core" {= version}
   "odoc" {with-doc}
 ]
 depopts: ["coq-native"]
@@ -43,7 +43,7 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["mv" "stdlib/coq-stdlib.install" "."]
+  ["mv" "stdlib/rocq-stdlib.install" "."]
 ]
 
 url {


### PR DESCRIPTION
To be merged in sync with https://github.com/coq/coq/pull/19973