### PR TITLE
[coq-rewriter] Bump minimal version to 8.18

### DIFF
--- a/extra-dev/packages/coq-rewriter/coq-rewriter.dev/opam
+++ b/extra-dev/packages/coq-rewriter/coq-rewriter.dev/opam
@@ -14,7 +14,7 @@ install: [make "install"]
 depends: [
   "conf-findutils" {build}
   "ocaml" {build & (arch = "x86_32" | arch = "x86_64" | >= "4.14.0")}
-  "coq" {>= "8.17~"}
+  "coq" {>= "8.18~"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rewriter.git"
 synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"


### PR DESCRIPTION
We don't test 8.17 on our CI anymore, so it probably doesn't work.