### PR TITLE
Relaxed OCaml version restriction in coq-coqprime-generator.1.1.2 from 5.0 to 4.14.2

### DIFF
--- a/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.2/opam
+++ b/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.2/opam
@@ -31,7 +31,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.14.2"}
+  "ocaml"
   "ocamlfind"
   "zarith"
   "num"

--- a/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.2/opam
+++ b/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.2/opam
@@ -31,7 +31,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.14.2"}
   "ocamlfind"
   "zarith"
   "num"


### PR DESCRIPTION
(tested to work)

See discussion in https://github.com/thery/coqprime/issues/81