### PR TITLE
Remove dune upper bound on 9.0+rc1 for the docker image

### DIFF
--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.0+rc1/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.0+rc1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8" & < "3.14"}
+  "dune" {>= "3.8"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}


### PR DESCRIPTION
We'll need to fix this seriously, it's a PITA.
C.f. https://github.com/coq-community/docker-rocq/pull/4#issuecomment-2632696798