### PR TITLE
Add missing rocq-bignums.dev

### DIFF
--- a/extra-dev/packages/rocq-bignums/rocq-bignums.dev/opam
+++ b/extra-dev/packages/rocq-bignums/rocq-bignums.dev/opam
@@ -1,22 +1,25 @@
 opam-version: "2.0"
-maintainer: "Laurent.Thery@inria.fr"
+maintainer: "pierre.roux@onera.fr"
 
-homepage: "https://github.com/coq/bignums"
-dev-repo: "git+https://github.com/coq/bignums.git"
-bug-reports: "https://github.com/coq/bignums/issues"
+homepage: "https://github.com/coq-community/bignums"
+dev-repo: "git+https://github.com/coq-community/bignums.git"
+bug-reports: "https://github.com/coq-community/bignums/issues"
 license: "LGPL-2.1-only"
 
-synopsis: "Bignums, the Coq library of arbitrary large numbers"
+synopsis: "Bignums, the Rocq library of arbitrarily large numbers"
 description: """
-Provides BigN, BigZ, BigQ that used to be part of Coq standard library
-"""
+This Rocq library provides BigN, BigZ, and BigQ that used to
+be part of the standard library."""
 
-build: [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
-install: [make "install"]
-
+build: [make "-j%{jobs}%"]
+install: [
+  [make "install"]
+  [make "-C" "tests" "-j%{jobs}%"] {with-test}
+]
 depends: [
   "ocaml"
-  "coq" {= "dev"}
+  "rocq-core" {= "dev"}
+  "rocq-stdlib"
 ]
 
 tags: [


### PR DESCRIPTION
Cc @proux01 

Follows-up: https://github.com/coq-community/docker-rocq/pull/5#issuecomment-2634258861

This package was missing and caused this build failure:

https://gitlab.com/coq-community/docker-rocq/-/jobs/9038615695