### PR TITLE
Package coq-pil.1.0.1

### DIFF
--- a/released/packages/coq-pil/coq-pil.1.0.1/opam
+++ b/released/packages/coq-pil/coq-pil.1.0.1/opam
@@ -27,7 +27,7 @@ install: [
 ]
 
 url {
-  src: "https://github.com/hferee/rocq-pil/archive/1.0.0.tar.gz"
+  src: "https://github.com/hferee/rocq-pil/archive/1.0.1.tar.gz"
   checksum: "sha256=45f516160f30506e2605fba55ff94c1d5dd53e43815b29b8d04b53119d0b43b2"
 }
 

--- a/released/packages/coq-pil/coq-pil.1.0.1/opam
+++ b/released/packages/coq-pil/coq-pil.1.0.1/opam
@@ -28,7 +28,7 @@ install: [
 
 url {
   src: "https://github.com/hferee/rocq-pil/archive/1.0.1.tar.gz"
-  checksum: "sha256=45f516160f30506e2605fba55ff94c1d5dd53e43815b29b8d04b53119d0b43b2"
+  checksum: "sha256=de73d133b8dd50539ff50208d82df13b0a5d7429f8be9ce27472211a6a0cabac"
 }
 
 tags: [

--- a/released/packages/coq-pil/coq-pil.1.0.1/opam
+++ b/released/packages/coq-pil/coq-pil.1.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Coq library for Propositional Intuitionistic Logic & Pitts Interpolation Library"
+
+homepage: "https://github.com/hferee/rocq-pil"
+dev-repo: "git+https://github.com/hferee/rocq-pil.git"
+bug-reports: "https://github.com/hferee/rocq-pil/issues"
+doc: "https://hferee.github.io/UIML"
+maintainer: "feree@irif.fr"
+authors: [
+  "Hugo Férée"
+  "Sam van Gool"
+  "Yago Iglesias Vasquez"
+]
+license: "CECILL-2.1"
+
+depends: [
+  "dune" {>= "3.8"}
+  "coq" {>= "8.20.1"}
+  "coq-stdpp" {>= "1.11.0"}
+  "coq-equations" {}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src: "https://github.com/hferee/rocq-pil/archive/1.0.0.tar.gz"
+  checksum: "sha256=45f516160f30506e2605fba55ff94c1d5dd53e43815b29b8d04b53119d0b43b2"
+}
+
+tags: [
+  "date:2025-02-14"
+  "keyword:intuitionistic logic"
+  "keyword:proof theory"
+  "keyword:propositional quantifiers"
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Mathematics/Logic/Foundations"
+  "category:Mathematics/Logic/Modal logic"
+  "logpath:ISL"
+]

--- a/released/packages/coq-pil/coq-pil.1.0.1/opam
+++ b/released/packages/coq-pil/coq-pil.1.0.1/opam
@@ -14,7 +14,7 @@ authors: [
 license: "CECILL-2.1"
 
 depends: [
-  "coq" {>= "8.20.1"}
+  "coq" {>= "8.20"}
   "coq-stdpp" {>= "1.11.0"}
   "coq-equations" {}
 ]

--- a/released/packages/coq-pil/coq-pil.1.0.1/opam
+++ b/released/packages/coq-pil/coq-pil.1.0.1/opam
@@ -14,7 +14,6 @@ authors: [
 license: "CECILL-2.1"
 
 depends: [
-  "dune" {>= "3.8"}
   "coq" {>= "8.20.1"}
   "coq-stdpp" {>= "1.11.0"}
   "coq-equations" {}


### PR DESCRIPTION
### `coq-pil.1.0.1`
Coq library for Propositional Intuitionistic Logic & Pitts Interpolation Library



---
* Homepage: https://github.com/hferee/rocq-pil
* Source repo: git+https://github.com/hferee/rocq-pil.git
* Bug tracker: https://github.com/hferee/rocq-pil/issues

---
:camel: Pull-request generated by opam-publish v2.5.0