### PR TITLE
Package coq-quickchick.2.1.1

### DIFF
--- a/released/packages/coq-quickchick/coq-quickchick.2.1.1/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.2.1.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Randomized Property-Based Testing for Coq"
+description: """\
+A library for property-based testing in Coq.
+
+  - Combinators for testable properties and random generators.
+  - QuickChick plugin for running tests in a Coq session.
+  - Includes a mutation testing tool."""
+maintainer: "leonidas@umd.edu"
+authors: [
+  "Leonidas Lampropoulos"
+  "Zoe Paraskevopoulou"
+  "Maxime Denes"
+  "Catalin Hritcu"
+  "Benjamin Pierce"
+  "Li-yao Xia"
+  "Arthur Azevedo de Amorim"
+  "Yishuai Li"
+  "Antal Spector-Zabusky"
+]
+license: "MIT"
+homepage: "https://github.com/QuickChick/QuickChick"
+bug-reports: "https://github.com/QuickChick/QuickChick/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.07"}
+  "menhir" {build}
+  "cppo" {build & >= "1.6.8"}
+  "coq" {>= "8.15~"}
+  "coq-ext-lib"
+  "coq-mathcomp-ssreflect"
+  "coq-simple-io" {>= "1.6.0"}
+  "ocamlfind"
+  "ocamlbuild"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+    "--stop-on-first-error"
+  ]
+]
+dev-repo: "git+https://github.com/QuickChick/QuickChick.git"
+url {
+  src:
+    "https://github.com/QuickChick/QuickChick/archive/refs/tags/v2.1.1.tar.gz"
+  checksum: [
+    "md5=0ebb3428fe7a79a46c76ccda4705498c"
+    "sha512=444a23e3e3d6d496a59c55b5c9ee8c1dd16cea259b331d2e9126d45950df522e07037e3f075861bf5ba15d8247a5f545a97c9ee424d011d076b7721aa50d8b06"
+  ]
+}


### PR DESCRIPTION
### `coq-quickchick.2.1.1`
Randomized Property-Based Testing for Coq
A library for property-based testing in Coq.

  - Combinators for testable properties and random generators.
  - QuickChick plugin for running tests in a Coq session.
  - Includes a mutation testing tool.



---
* Homepage: https://github.com/QuickChick/QuickChick
* Source repo: git+https://github.com/QuickChick/QuickChick.git
* Bug tracker: https://github.com/QuickChick/QuickChick/issues

---
:camel: Pull-request generated by opam-publish v2.5.1