### PR TITLE
fix infotheo 0.9.3

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.9.3/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.9.3/opam
@@ -1,6 +1,3 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
-
 opam-version: "2.0"
 maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
 version: "dev"
@@ -27,7 +24,7 @@ depends: [
   "coq-mathcomp-algebra"
   "coq-mathcomp-solvable"
   "coq-mathcomp-field"
-  "coq-mathcomp-analysis" { (>= "1.10.0") }
+  "coq-mathcomp-analysis" { (>= "1.10.0") & (< "1.12.0") }
   "coq-mathcomp-reals-stdlib" { (>= "1.10.0") }
   "coq-hierarchy-builder" { >= "1.7.0" & < "1.9.1" }
   "coq-mathcomp-algebra-tactics" { >= "1.2.0" }


### PR DESCRIPTION
does not compile with mathcomp-analysis 1.12.0