### PR TITLE
Add upper bound < 9.1.0 for coq-coqprime

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.6.0/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.6.0/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.20" & < "8.21"}
+  "coq" {>= "8.20" & < "9.1.0"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
This PR adds an upper bound < "9.1.0" to the coq dependency for the following package(s):
- coq-coqprime

This is required for compatibility with Rocq 9.0 and was tested successfully as part of the Rocq Platform 9.0 release preparation.

/cc @MSoegtropIMC 