### PR TITLE
Release coq-lean-import

### DIFF
--- a/released/packages/coq-lean-import/coq-lean-import.8.20+lean3-alpha/opam
+++ b/released/packages/coq-lean-import/coq-lean-import.8.20+lean3-alpha/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 maintainer: "gaetan.gilbert@skyskimmer.net"
-version: "8.20+lean3-alpha"
 
 homepage: "https://github.com/rocq-community/rocq-lean-import"
 dev-repo: "git+https://github.com/rocq-community/rocq-lean-import.git"

--- a/released/packages/coq-lean-import/coq-lean-import.9.0+lean3-alpha/opam
+++ b/released/packages/coq-lean-import/coq-lean-import.9.0+lean3-alpha/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 maintainer: "gaetan.gilbert@skyskimmer.net"
-version: "9.0+lean3-alpha"
 
 homepage: "https://github.com/rocq-community/rocq-lean-import"
 dev-repo: "git+https://github.com/rocq-community/rocq-lean-import.git"


### PR DESCRIPTION
These versions are for importing Lean 3.  The version compatible with Rocq 9.1 will be for Lean 4.  I'm not sure whether to use +lean3-alpha or -lean3+alpha.  The +lean3 will probably be entirely dropped in future versions (rather than becoming +lean4).

cc @SkySkimmer 