### PR TITLE
fix: update constraint version package coq-libhyps to Coq Platform 8.20

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.3.0.1/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.3.0.1/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 
 depends: [
-  "coq" {(>= "8.11" & <= "8.21~")}
+  "coq" {(>= "8.11" & < "8.21~")}
 ]
 
 tags: [

--- a/released/packages/coq-libhyps/coq-libhyps.3.0.2/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.3.0.2/opam
@@ -25,7 +25,7 @@ install: [make "install"]
 
 depends: [
   "ocaml" {>= "4.14"}
-  "coq" {(>= "8.11" & <= "8.21~")}
+  "coq" {(>= "8.11" & < "8.21~")}
 ]
 
 tags: [


### PR DESCRIPTION
Our CI is currently failing because the Coq version constraint for coq-libhyps was changed in this commit:
https://github.com/rocq-prover/opam/commit/147898de2c76d6de7a85525382e4ecf912dca5f9

 -  "coq" {(>= "8.11" & < "8.21~") | (= "dev")}
 + "coq" {(>= "8.11" & <= "8.20~")}

The bound <= "8.20~" actually excludes 8.20.x (8.20.1), which breaks the 8.20 builds. I propose reverting to: "coq" {(>= "8.11" & < "8.21~")} so 8.20.x is allowed again.
