### PR TITLE
fix: apply Windows build workaround

### DIFF
--- a/released/packages/coq-interval/coq-interval.4.11.3/opam
+++ b/released/packages/coq-interval/coq-interval.4.11.3/opam
@@ -6,6 +6,7 @@ bug-reports: "https://gitlab.inria.fr/coqinterval/interval/issues"
 license: "CeCILL-C"
 build: [
   ["autoconf"] {dev}
+  ["sed" "-i" "-e" "s/@COQDEP@/@COQDEP@ -worker \\\"\\\"/" "Remakefile.in"] {os = "win32"}
   ["./configure"]
   ["./remake" "-j%{jobs}%"]
 ]


### PR DESCRIPTION
Add   ["sed" "-i" "-e" "s/@COQDEP@/@COQDEP@ -worker \\\"\\\"/" "Remakefile.in"] {os = "win32"} to fix the issue of coqdep on windows