### PR TITLE
Package rocq-rouche-capelli.0.1.0

### DIFF
--- a/released/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.1.0/opam
+++ b/released/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.1.0/opam
@@ -47,7 +47,7 @@ url {
   src:
     "https://github.com/weng-chenghui/rocq-rouche-capelli/archive/refs/tags/v0.1.0.tar.gz"
   checksum: [
-    "md5=ef496b73bc5c47cc6e399bca73028c60"
-    "sha512=684c49d614f86fbc7f0daf7f35bdae58d094a2bb331c6e72a88d13daff1b9208fcd8cfbad081115aa8078f61e02013996e169b58c769abeb63f0d6ba2dd66de0"
+    "md5=593c97545df488e049db5eb6bf6b7940"
+    "sha512=789bd0a44d0354dd5d6b3a75103d3cc231891513a18d3699fa8ce4fe0407007767006cbdee218bf69076955bd1934c1d9edbe7205dd8b32c41a1c92c9a56533f"
   ]
 }


### PR DESCRIPTION
### `rocq-rouche-capelli.0.1.0`
A proof for the Rouché–Capelli theorem by rocq-math-comp
This package provides a formal proof of the Rouché–Capelli theorem (also known as
the Kronecker–Capelli theorem) using the Rocq Prover and the Mathematical Components
library. The theorem provides necessary and sufficient conditions for a system of
linear equations to have solutions, stating that a system is consistent if and only
if the rank of its coefficient matrix equals the rank of its augmented matrix.



---
* Homepage: https://github.com/weng-chenghui/rocq-rouche-capelli
* Source repo: git+https://github.com/weng-chenghui/rocq-rouche-capelli.git
* Bug tracker: https://github.com/weng-chenghui/rocq-rouche-capelli/issues

---
:camel: Pull-request generated by opam-publish v2.6.0