### PR TITLE
Allow Rocq 9.1 for coq-record-update 0.3.6

### DIFF
--- a/released/packages/coq-record-update/coq-record-update.0.3.6/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.6/opam
@@ -16,7 +16,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "9.1") | (= "dev")}
+  "coq" {(>= "8.14" & < "9.2") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
The update "just worked" without requiring [any changes](https://github.com/tchajed/coq-record-update/compare/v0.3.6...667b414b4072770ff7bbca72aa90bf18510c1d00), so the source remains unchanged.

See https://github.com/tchajed/coq-record-update/pull/61

CC @tchajed @MackieLoeffel 