### PR TITLE
Package coq-formalv-1.4.0

### DIFF
--- a/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.4.0/opam
+++ b/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Tactics to automatically prove Boolean goals involving Uint63/Sint63 variables" # One-line description
+description: """
+FV Check Range provides tactics to automatically prove Boolean goals
+involving 1, 2 or 3 Uint63.int/Sint63.int bounded variables through
+brute-force computation.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/formalv/coqdoc/toc.html"
+maintainer: "Mireia González Bedmar <mireia.gonzalez@formalv.com>"
+
+tags: [
+  "keyword:automation"
+  "keyword:primitive integers"
+  "logpath:formalv.check_range"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {(>= "8.19" & < "8.21~")}
+  "coq-mathcomp-ssreflect" {(>= "2.3.0" & < "2.4~")}
+  "coq-mathcomp-algebra" {(>= "2.3.0" & < "2.4~")}
+  "coq-formalv-prim63_mathcomp" {= version}
+]
+
+build: [
+  [make "-C" "theories/check_range" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/check_range" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.4.0/formalv-1.4.0.tar.gz"
+  checksum: "sha512=10e582991ec1ba10f0d448500d6a87a6116a713ee74435ab80f8a61df5f0e4caa1f7d5e5239635e01c6204b3b75a6c2b3b9ae3c3f8925e0c7cf3f83e9dcfb506"
+}

--- a/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.4.0/opam
+++ b/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Refinements from MathComp nat and int to Coq primitive integers Uint63/Sint63" # One-line description
+description: """
+FV Prim63 to MathComp provides conversions from the Coq primitive integers
+Uint63 and Sint63 to the MathComp natural and integer numbers nat and int,
+and vice versa, as well as lemmas to rewrite between their respective
+operations.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/formalv/coqdoc/toc.html"
+
+maintainer: "Mireia González Bedmar <mireia.gonzalez@formalv.com>"
+
+tags: [
+  "keyword:refinement"
+  "keyword:primitive integers"
+  "logpath:formalv.prim63_mathcomp"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {(>= "8.19" & < "8.21~")}
+  "coq-mathcomp-ssreflect" {(>= "2.3.0" & < "2.4~")}
+  "coq-mathcomp-algebra" {(>= "2.3.0" & < "2.4~")}
+]
+
+build: [
+  [make "-C" "theories/prim63_mathcomp" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/prim63_mathcomp" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.4.0/formalv-1.4.0.tar.gz"
+  checksum: "sha512=10e582991ec1ba10f0d448500d6a87a6116a713ee74435ab80f8a61df5f0e4caa1f7d5e5239635e01c6204b3b75a6c2b3b9ae3c3f8925e0c7cf3f83e9dcfb506"
+}

--- a/released/packages/coq-formalv-time/coq-formalv-time.1.4.0/opam
+++ b/released/packages/coq-formalv-time/coq-formalv-time.1.4.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A Coq library for time and date arithmetic according to the UTC standard with leap seconds" # One-line description
+description: """
+FV Time is a library for managing conversions between time formats (UTC and
+timestamps), as well as commonly used functions for time arithmetic. As a
+library for time conversions, its novelty is the implementation of leap
+seconds (which are part of the UTC standard but usually not implemented in
+commercial libraries).
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/formalv/coqdoc/toc.html"
+maintainer: "Mireia González Bedmar <mireia.gonzalez@formalv.com>"
+
+tags: [
+  "keyword:time"
+  "keyword:date"
+  "keyword:timestamp"
+  "logpath:formalv.time"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {(>= "8.19" & < "8.21~")}
+  "coq-mathcomp-ssreflect" {(>= "2.3.0" & < "2.4~")}
+  "coq-mathcomp-algebra" {(>= "2.3.0" & < "2.4~")}
+  "coq-formalv-prim63_mathcomp" {= version}
+  "coq-formalv-check_range" {= version}
+]
+
+build: [
+  [make "-C" "theories/time" "-j" "%{jobs}%"]
+]
+
+install: [
+  [make "-C" "theories/time" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.4.0/formalv-1.4.0.tar.gz"
+  checksum: "sha512=10e582991ec1ba10f0d448500d6a87a6116a713ee74435ab80f8a61df5f0e4caa1f7d5e5239635e01c6204b3b75a6c2b3b9ae3c3f8925e0c7cf3f83e9dcfb506"
+}


### PR DESCRIPTION
A new version of packages:

- `coq-formalv-check_range`
- `coq-formalv-prim63_mathcomp`
- `coq-formalv-time`

Now Unix time computations (i.e., no leap seconds) are supported.

Compatible with Coq 8.19 and 8.20.