### PR TITLE
Fix version constraints on rocq-equations.1.3.1+9.1

### DIFF
--- a/released/packages/rocq-equations/rocq-equations.1.3.1+9.1/opam
+++ b/released/packages/rocq-equations/rocq-equations.1.3.1+9.1/opam
@@ -19,8 +19,8 @@ bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
 depends: [
   "dune" {>= "3.13"}
   "ocaml" {>= "4.10.0"}
-  "rocq-core" {>= "9.0~" & < "9.2"}
-  "coq-core" {>= "9.0~"} # For dune coq lang
+  "rocq-core" {>= "9.1~" & < "9.2"}
+  "coq-core" {>= "9.1~"} # For dune coq lang
   "rocq-stdlib" {>= "9.0~"}
   "ppx_optcomp" {build}
   "ocaml-lsp-server" {with-dev-setup}


### PR DESCRIPTION
For some reason I thought equations was using optcomp but I guess not