### PR TITLE
Fix compilation of ValidSDP with Rocq 9.1

### DIFF
--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.1.1.0/opam
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.1.1.0/opam
@@ -14,7 +14,8 @@ build: [
 ]
 install: [make "-C" "libvalidsdp" "install"]
 depends: [
-  "coq" {>= "9.0" & < "9.2~"}
+  "coq-core" {>= "9.0" & < "9.2~"}
+  "coq-stdlib" {>= "9.0" & < "9.1~"}
   "coq-bignums"
   "coq-flocq" {>= "3.3.0"}
   "coq-coquelicot" {>= "3.0"}

--- a/released/packages/coq-validsdp/coq-validsdp.1.1.0/opam
+++ b/released/packages/coq-validsdp/coq-validsdp.1.1.0/opam
@@ -17,12 +17,6 @@ install: [make "install"]
 
 depends: [
   "ocaml"
-  "coq" {>= "9.0" & < "9.2~"}
-  "coq-bignums"
-  "coq-flocq" {>= "3.3.0"}
-  "coq-interval" {>= "4.0.0" & < "5~"}
-  "coq-mathcomp-field" {>= "2.3" & < "2.5~"}
-  "coq-mathcomp-reals-stdlib" {>= "1.8.0"}
   "coq-libvalidsdp" {= version}
   "coq-mathcomp-multinomials" {>= "2.0"}
   "coq-coqeal" {>= "2.1"}


### PR DESCRIPTION
ci-skip: coq-libvalidsdp