### PR TITLE
Hierarchy Builder 1.10.0 and 1.10.1 are incompatible with Elpi >= 3.4.3

### DIFF
--- a/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.0/opam
+++ b/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.0/opam
@@ -16,6 +16,7 @@ depends: [
   ("coq" {>= "8.20" & < "8.21~"} & "coq-elpi" {>= "3" | = "dev"} |
    "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"} &
    "rocq-elpi" {>= "3" | = "dev"})
+  "elpi" {< "3.4.3~"}
 ]
 conflicts: [
   "coq-hierarchy-builder" {< "1.9~"}

--- a/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.1/opam
+++ b/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.1/opam
@@ -16,6 +16,7 @@ depends: [
   ("coq" {>= "8.20" & < "8.21~"} & "coq-elpi" {>= "3" | = "dev"} |
    "rocq-core" {(>= "9.0" & < "9.1~") | = "dev"} &
    "rocq-elpi" {>= "3" | = "dev"})
+  "elpi" {< "3.4.3~"}
 ]
 conflicts: [
   "coq-hierarchy-builder" {< "1.9~"}


### PR DESCRIPTION
Ping @gares who fixed the issue in https://github.com/math-comp/hierarchy-builder/pull/562