### PR TITLE
CoqEAL 2.1.0 compiles with Rocq 9.1

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.2.1.0/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.2.1.0/opam
@@ -17,7 +17,7 @@ of the ForMath EU FP7 project (2009-2013). It has two parts:
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.20" & < "9.1~") | (= "dev")}
+  "coq" {(>= "8.20" & < "9.2~") | (= "dev")}
   "coq-bignums"
   "coq-elpi" {>= "2.5.0" & < "3.2~"}
   "coq-hierarchy-builder" {>= "1.4.0"}

--- a/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.2/opam
+++ b/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.2/opam
@@ -18,7 +18,7 @@ library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "9.1~") | (= "dev")}
+  "coq" {(>= "8.10" & < "9.2~") | (= "dev")}
   "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
 

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.2.4.0/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.2.4.0/opam
@@ -9,7 +9,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
    ("coq" {>= "8.18" & < "8.21~"}
-   | "coq-core" {>= "9.0" & < "9.1~"})
+   | "coq-core" {>= "9.0" & < "9.2~"})
   "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.5~") | = "dev"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}

--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.3/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.2.0.3/opam
@@ -18,7 +18,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   ("coq" {>= "8.18" & < "8.21~"}
-  | "coq-core" {>= "9.0" & < "9.1~"})
+  | "coq-core" {>= "9.0" & < "9.2~"})
   "coq-mathcomp-ssreflect" {>= "2.2.0" & < "2.5~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-field"


### PR DESCRIPTION
ci-skip: coq-mathcomp-bigenough coq-mathcomp-multinomials coq-mathcomp-real-closed