### PR TITLE
Package rocq-rouche-capelli.0.2.0

### DIFF
--- a/released/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.2.0/opam
+++ b/released/packages/rocq-rouche-capelli/rocq-rouche-capelli.0.2.0/opam
@@ -28,13 +28,13 @@ tags: [
 ]
 depends: [
   "rocq-core" {>= "9.0.0" & < "9.1~"}
-  "rocq-mathcomp-ssreflect" {= "2.4.0"}
-  "rocq-mathcomp-algebra" {= "2.4.0"}
-  "rocq-mathcomp-field" {= "2.4.0"}
-  "rocq-mathcomp-fingroup" {= "2.4.0"}
+  "rocq-mathcomp-ssreflect" {>= "2.4.0"}
+  "rocq-mathcomp-algebra" {>= "2.4.0"}
+  "rocq-mathcomp-field" {>= "2.4.0"}
+  "rocq-mathcomp-fingroup" {>= "2.4.0"}
   "rocq-mathcomp-finmap" {>= "2.1.0"}
-  "rocq-mathcomp-solvable" {= "2.4.0"}
-  "coq-mathcomp-classical" {= "1.13.0"}
+  "rocq-mathcomp-solvable" {>= "2.4.0"}
+  "coq-mathcomp-classical" {>= "1.13.0"}
 ]
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile.coq"]


### PR DESCRIPTION
# Package rocq-rouche-capelli.0.2.0

Upgrade of `rocq-rouche-capelli` to version 0.2.0.

## What's New in 0.2.0

- Affine solution counting for inhomogeneous linear systems over finite fields
- Proof that affine solution sets are translates of kernel solutions
- Explicit cardinality formula: |solutions| = |K|^(n - rank(A))
- Column vector variants for standard matrix equations (A*v = b)
- Bijection proofs via matrix transpose for column vectors
- Concrete example for rank-1 systems (ax + by = z)