### PR TITLE
Kruskal-Trees v2.0 (Rocq only)

### DIFF
--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.2.0/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem"
+description: """
+   Several implementations for roses trees are proposed with proper induction principles. 
+   Sons of the root are collected into dependent vectors, vectors, lists, etc.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)" "Jerome Hugues (https://github.com/jjhugues)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Trees/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Trees/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Trees/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "rocq-core" {>= "9.0.0" & < "9.2~"}
+  "rocq-stdlib" {}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Trees/releases/download/2.0/Kruskal-Trees-2.0.tar.gz"
+  checksum: [
+    "sha256=9717b15e5939019a62f7a9ace50e10572ba8498937be19f0971a4b459cd07fd3"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2025-11-18"
+  "logpath:KruskalTrees"
+]
+


### PR DESCRIPTION
This is an update of `coq-kruskal-trees` fit for Rocq `9.0` and `9.1`, but not for `Coq`. The main change is replacing `From Coq` with `From Stdlib` in every `*.v` file. No functionality change.