### PR TITLE
menir.dev depend on ocaml >= 5

### DIFF
--- a/extra-dev/packages/menhir/menhir.dev/opam
+++ b/extra-dev/packages/menhir/menhir.dev/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "5.4.0"}
   "dune" { >= "2.2.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}


### PR DESCRIPTION
The author isn't checking ocaml 4 versions when pushing.

see also https://rocq-prover.zulipchat.com/#narrow/channel/237656-Rocq-devs-.26-plugin-devs/topic/menhir.20min.20ocaml.20version.3F/with/555633598