### PR TITLE
coq-dpdgraph for rocq-9.1

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.1.0+9.1/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.1.0+9.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/coq-dpdgraph"
+dev-repo: "git+https://github.com/coq-community/coq-dpdgraph.git"
+bug-reports: "https://github.com/coq-community/coq-dpdgraph/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Compute dependencies between Coq objects (definitions, theorems) and produce graphs"
+description: """
+Coq plugin that extracts the dependencies between Coq objects,
+and produces files with dependency information. Includes tools
+to visualize dependency graphs and find unused definitions."""
+
+build: [
+  [make "-j%{jobs}%" "WARN_ERR="]
+]
+install: [make "install" "BINDIR=%{bin}%"]
+depends: [
+  "coq" {>= "9.1" & < "9.2~"}
+  "ocamlgraph" 
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:dependency graph"
+  "keyword:dependency analysis"
+  "logpath:dpdgraph"
+  "date:2025-05-28"
+]
+authors: [
+  "Anne Pacalet"
+  "Yves Bertot"
+  "Olivier Pons"
+]
+
+url {
+  src : "https://github.com/rocq-community/coq-dpdgraph/releases/download/v1.0%2B9.1/coq-dpdgraph-1.0-9.1.tgz"
+  checksum: "sha512=2700a191c7c90f893e9a81aff0878bcfaea72c4b67d8c7707f8da95c1d544b7c09654f87051b361cca4f8c4a92d9e30d6eb52e70d3928d68a680cb923d1fbcac"
+}


### PR DESCRIPTION
The compilation has been simplified, there is no need for configure anymore.
I also removed dependencies on Ocaml, keeping only the dependency on coq.
Next step would be to have a direct dependency on rocq and no more dependency on coq.  This was not investigated.
The archive file was created using "git archive"
