### PR TITLE
release of Robot Rocq 0.3.1

### DIFF
--- a/released/packages/rocq-robot-rocq/rocq-robot-rocq.0.3.1/opam
+++ b/released/packages/rocq-robot-rocq/rocq-robot-rocq.0.3.1/opam
@@ -34,7 +34,7 @@ depends: [
 tags: [
   "keyword:robotics"
   "keyword:3D geometry"
-  "logpath:robot-rocq"
+  "logpath:robot"
   "date:2026-01-10"
 ]
 authors: [


### PR DESCRIPTION
This is a release compatible with MathComp 2.5.0

@weng-chenghui @garrigue @t6s