### PR TITLE
release MathComp-Analysis 1.15.0

### DIFF
--- a/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.15.0/opam
+++ b/released/packages/coq-mathcomp-analysis-stdlib/coq-mathcomp-analysis-stdlib.1.15.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "analysis_stdlib" "-j%{jobs}%"]
+install: [make "-C" "analysis_stdlib" "install"]
+depends: [
+  "coq-mathcomp-analysis" { = version}
+  "coq-mathcomp-reals-stdlib"
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.15.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.1.15.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This package contains a library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "theories" "-j%{jobs}%"]
+install: [make "-C" "theories" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-solvable"
+  "coq-mathcomp-field"
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:analysis"
+  "keyword:Cantor"
+  "keyword:topology"
+  "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
+  "logpath:mathcomp.analysis"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}

--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.15.0/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.1.15.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for classical logic for mathematical components"
+description: """
+This repository contains a library for classical logic for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "classical" "-j%{jobs}%"]
+install: [make "-C" "classical" "install"]
+depends: [
+  ("coq" {>= "8.20" & < "8.21~"}
+  | "coq-core" { (>= "9.0" & < "9.1~") | (= "dev") })
+  "coq-mathcomp-ssreflect" { (>= "2.4.0" & < "2.6~") | (= "dev") }
+  "coq-mathcomp-fingroup"
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-finmap" { (>= "2.1.0") }
+  "coq-hierarchy-builder" { (>= "1.8.0") }
+]
+
+tags: [
+  "category:Mathematics/Logic/Classical logic"
+  "keyword:classical logic"
+  "keyword:logic"
+  "keyword:sets"
+  "keyword:set theory"
+  "keyword:function"
+  "keyword:cardinal"
+  "keyword:filter"
+  "logpath:mathcomp.classical"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}

--- a/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.15.0/opam
+++ b/released/packages/coq-mathcomp-experimental-reals/coq-mathcomp-experimental-reals.1.15.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for alternative real numbers for mathematical components"
+description: """
+This package contains an experiment along real numbers
+made at the beginning of the MathComp-Analysis library
+(which now offers the coq-mathcomp-reals package).
+
+Beware that this still contains a few Admitted."""
+
+build: [make "-C" "experimental_reals" "-j%{jobs}%"]
+install: [make "-C" "experimental_reals" "install"]
+depends: [
+  "coq-mathcomp-reals" { = version}
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.experimental_reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}

--- a/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.15.0/opam
+++ b/released/packages/coq-mathcomp-reals-stdlib/coq-mathcomp-reals-stdlib.1.15.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "reals_stdlib" "-j%{jobs}%"]
+install: [make "-C" "reals_stdlib" "install"]
+depends: [
+  ("coq" {< "8.21~"}
+  | "rocq-stdlib" { (>= "9.0" & < "9.1~") | (= "dev") })
+  "coq-mathcomp-reals" { = version}
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}

--- a/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.15.0/opam
+++ b/released/packages/coq-mathcomp-reals/coq-mathcomp-reals.1.15.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for real numbers for mathematical components"
+description: """
+This package contains a library for real numbers for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "reals" "-j%{jobs}%"]
+install: [make "-C" "reals" "install"]
+depends: [
+  "coq-mathcomp-classical" { = version}
+]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "keyword:extended real numbers"
+  "logpath:mathcomp.reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.15.0/analysis-1.15.0.tar.gz"
+checksum: "sha256=2df4d0b1d5e6b1f6260853953166d85441f6b76fd4ab7f9548a0b5d24a95c4cb"
+}


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical coq-mathcomp-reals coq-mathcomp-analysis coq-mathcomp-reals-stdlib