### PR TITLE
Rocq 9.2+ release of the Coq Kruskal project

### DIFF
--- a/released/packages/coq-kruskal-almostfull/coq-kruskal-almostfull.2.2/opam
+++ b/released/packages/coq-kruskal-almostfull/coq-kruskal-almostfull.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Base Coq library for manipulating Almost Full relations"
+description: """
+   This library formalizes ground results about Almost Full relations (AF) in Coq 8.14+, up to Dickson's lemma.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-AlmostFull/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-AlmostFull/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-AlmostFull/"
+
+build: [
+  [ make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "rocq-core" {>= "9.2.0" & < "9.3~"}
+  "rocq-stdlib"
+  "coq-kruskal-trees" {>= "2.0"} 
+  "coq-kruskal-finite" {>= "2.0"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-AlmostFull/releases/download/2.2/Kruskal-AlmostFull-2.2.tar.gz"
+  checksum: [ 
+    "sha256=ef215b6dc725f79e6db40a788b61baef69469acb3c4d96dc2a808cbe2d947a9b"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalAfProp"
+  "logpath:KruskalAfType"
+]

--- a/released/packages/coq-kruskal-fan/coq-kruskal-fan.2.2/opam
+++ b/released/packages/coq-kruskal-fan/coq-kruskal-fan.2.2/opam
@@ -27,7 +27,7 @@ depends: [
 url {
   src: "https://github.com/DmxLarchey/Kruskal-Fan/releases/download/2.2/Kruskal-Fan-2.2.tar.gz"
   checksum: [
-    "sha256:73f7c247de10f31a2343dd458ac58ecea9d297036fa2273d9372151420cf3b49"
+    "sha256=73f7c247de10f31a2343dd458ac58ecea9d297036fa2273d9372151420cf3b49"
   ]
 }
  

--- a/released/packages/coq-kruskal-fan/coq-kruskal-fan.2.2/opam
+++ b/released/packages/coq-kruskal-fan/coq-kruskal-fan.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Extending Coq library for manipulating Almost Full relations with the FAN theorem"
+description: """
+   This library formalizes additional tools for AF relations, the FAN theorem for inductive bars
+   and a constructive variant of König's lemma.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Fan"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Fan/issues"
+dev-repo: "git+https://github.com/DmxLarchey/Kruskal-Fan/"
+
+build: [
+  [make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees"
+  "coq-kruskal-finite"
+  "coq-kruskal-almostfull" {>= "2.2"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Fan/releases/download/2.2/Kruskal-Fan-2.2.tar.gz"
+  checksum: [
+    "sha256:73f7c247de10f31a2343dd458ac58ecea9d297036fa2273d9372151420cf3b49"
+  ]
+}
+ 
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalFanProp"
+  "logpath:KruskalFanType"
+]

--- a/released/packages/coq-kruskal-finite/coq-kruskal-finite.2.2/opam
+++ b/released/packages/coq-kruskal-finite/coq-kruskal-finite.2.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating finiteness, finite choice and decision as used in proof of Kruskal's tree theorem"
+description: """
+   Tools to facilitate proofs of finiteness (ie listability), finite choice principles
+   and finite decidability.
+"""
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"]
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Finite/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Finite/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Finite/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "rocq-core" {>= "9.2.0" & < "9.3~"}
+  "rocq-stdlib"
+  "coq-kruskal-trees" {>= "2.2"} 
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Finite/releases/download/2.2/Kruskal-Finite-2.2.tar.gz"
+  checksum: [
+    "sha256=0be35bc4d6d6c5e623b25fbed65b43c1b506615929a2c5400e3be84144f2ab4a"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalFinite"
+]

--- a/released/packages/coq-kruskal-higman/coq-kruskal-higman.2.2/opam
+++ b/released/packages/coq-kruskal-higman/coq-kruskal-higman.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+name: "Coq-Kruskal-Higman"
+synopsis: "Extending Coq library for manipulating Almost Full relations with Higman's lemma"
+description: """
+   This library formalizes additional tools for AF relations, eg quasi morphisms applied to Higman's lemma.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Higman/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Higman/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Higman/"
+
+build: [
+  [make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees"
+  "coq-kruskal-finite"
+  "coq-kruskal-almostfull" {>= "2.2"}
+  "coq-kruskal-fan" {>= "2.2"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Higman/releases/download/2.2/Kruskal-Higman-2.2.tar.gz"
+  checksum: [
+    "sha256=1923bf3c1efb7075d255d838a6078740ee63c8b37ff5bb688e8479d5b553d44f"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalHigmanProp"
+  "logpath:KruskalHigmanType"
+]

--- a/released/packages/coq-kruskal-theorems/coq-kruskal-theorems.2.2/opam
+++ b/released/packages/coq-kruskal-theorems/coq-kruskal-theorems.2.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+name: "Coq-Kruskal-Theorems"
+synopsis: "Extending the Coq library for manipulating Almost Full relations with various forms of Kruskal's tree theorem"
+description: """
+   This library formalizes the high-level variants of Higman's theorem (for trees of bounded arity)
+   and Kruskal's theorem (for rose trees), depending on how these datatypes are implemented. Also,
+   Vazsonyi's conjecture to illustrate the expressive power of Kruskal's and Higman's theorem.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Theorems/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Theorems/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Theorems/"
+
+build: [
+  [make "-j%{jobs}%" "type"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees"
+  "coq-kruskal-almostfull"
+  "coq-kruskal-higman"     {>= "2.2"}
+  "coq-kruskal-veldman"    {>= "2.2"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Theorems/releases/download/2.2/Kruskal-Theorems-2.2.tar.gz"
+  checksum: [
+    "sha256=a70c72a3ee91bb307e36bcc65c21fee648e5cace0942f86daa4e7993a933ecf8"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalThmProp"
+  "logpath:KruskalThmType"
+]
+

--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.2.2/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.2.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem"
+description: """
+   Several implementations for roses trees are proposed with proper induction principles. 
+   Sons of the root are collected into dependent vectors, vectors, lists, etc.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)" "Jerome Hugues (https://github.com/jjhugues)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Trees/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Trees/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Trees/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "rocq-core" {>= "9.2.0" & < "9.3~"}
+  "rocq-stdlib"
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Trees/releases/download/2.2/Kruskal-Trees-2.2.tar.gz"
+  checksum: [
+     "sha256=3ab03eb06a9261873344e3146c8ceead9ad5e69caf608c574f3c3630e6dd9ffb"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalTrees"
+]
+

--- a/released/packages/coq-kruskal-veldman/coq-kruskal-veldman.2.2/opam
+++ b/released/packages/coq-kruskal-veldman/coq-kruskal-veldman.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Wim Veldman's proof of Higman's and Kruskal tree theorems"
+description: """
+   This library formalizes additional tools for AF relations, eg AF lexicographic induction 
+   and relational quasi morphisms applied to Wim Veldman's constructive proof of the tree theorem.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "MPL-2.0"
+homepage: "https://github.com/DmxLarchey/Kruskal-Veldman/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Veldman/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Veldman/"
+
+build: [
+  [make "-j%{jobs}%" "prop"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq-kruskal-trees"
+  "coq-kruskal-finite"
+  "coq-kruskal-almostfull" {>= "2.2"}
+  "coq-kruskal-fan"
+  "coq-kruskal-higman"     {>= "2.2"}
+]
+
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Veldman/releases/download/2.2/Kruskal-Veldman-2.2.tar.gz"
+  checksum: [
+    "sha256=aa440a136586c5bdf2171e10e9cade2f935a94da916daf030e5cfc6c34446ae2"
+  ]
+}
+
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2026-04-12"
+  "logpath:KruskalVeldmanProp"
+  "logpath:KruskalVeldmanType"
+]
+


### PR DESCRIPTION
This release is Rocq `9.2+` only because of now commands like `Abbreviation` or `Register Scheme`... No change in functionality though.

Reference: https://github.com/DmxLarchey/Coq-Kruskal

ci-skip: coq-kruskal-trees coq-kruskal-finite coq-kruskal-almostfull coq-kruskal-fan coq-kruskal-higman coq-kruskal-veldman