### PR TITLE
Package rocq-listz.20260414

### DIFF
--- a/released/packages/rocq-listz/rocq-listz.20260414/opam
+++ b/released/packages/rocq-listz/rocq-listz.20260414/opam
@@ -1,0 +1,30 @@
+
+opam-version: "2.0"
+synopsis: "A Rocq library of lists with indices in Z"
+maintainer: "François Pottier <francois.pottier@inria.fr>"
+authors: "François Pottier <francois.pottier@inria.fr>"
+homepage: "https://gitlab.inria.fr/fpottier/listz"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/listz/"
+bug-reports: "https://gitlab.inria.fr/fpottier/listz/issues"
+license: "LGPL-2.1-only"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@install" ]
+]
+tags: [
+  "date:2026-04-14"
+  "logpath:listz"
+]
+depends: [
+  "rocq-core" { (>= "9.0") }
+  "rocq-stdlib"
+  "rocq-stdpp" { (>= "1.13.0") }
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/listz/-/archive/20260414/archive.tar.gz"
+  checksum: [
+    "md5=531e1edbbf554c21fbcf42b78f3c1368"
+    "sha512=da56246260f3a72a4d3d95a01cce0125dddce5c650131929e6fa3ea630370ff543ab6cd0346232e8ac8d87a5378aebf994dabf7639c6ff3782a449ed6d7e53de"
+  ]
+}


### PR DESCRIPTION
### `rocq-listz.20260414`
A Rocq library of lists with indices in Z



---
* Homepage: https://gitlab.inria.fr/fpottier/listz
* Source repo: git+https://gitlab.inria.fr/fpottier/listz/
* Bug tracker: https://gitlab.inria.fr/fpottier/listz/issues

---
:camel: Pull-request generated by opam-publish v2.3.0