### PR TITLE
Package rocq-listz.20260414

### DIFF
--- a/released/packages/rocq-listz/rocq-listz.20260414/opam
+++ b/released/packages/rocq-listz/rocq-listz.20260414/opam
@@ -1,0 +1,30 @@
+
+opam-version: "2.0"
+synopsis: "A Rocq library of lists with indices in Z"
+maintainer: "François Pottier <francois.pottier@inria.fr>"
+authors: "François Pottier <francois.pottier@inria.fr>"
+homepage: "https://gitlab.inria.fr/fpottier/listz"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/listz/"
+bug-reports: "https://gitlab.inria.fr/fpottier/listz/issues"
+license: "LGPL-2.1-only"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@install" ]
+]
+tags: [
+  "date:2026-04-14"
+  "logpath:listz"
+]
+depends: [
+  "rocq-core" { (>= "9.0") }
+  "rocq-stdlib"
+  "rocq-stdpp" { (>= "1.13.0") }
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/listz/-/archive/20260414/archive.tar.gz"
+  checksum: [
+    "md5=dcbde2b5202fcb8000a143d3a0a5ce5a"
+    "sha512=b7f8b2cc40068d2c3eb648106aa31314479a711764d2d368812320f4373bf0a8c2524b78274e94c02c74933afaaf3b66892d4cf0c436d2db3c569e694de978d1"
+  ]
+}


### PR DESCRIPTION
### `rocq-listz.20260414`
A Rocq library of lists with indices in Z



---
* Homepage: https://gitlab.inria.fr/fpottier/listz
* Source repo: git+https://gitlab.inria.fr/fpottier/listz/
* Bug tracker: https://gitlab.inria.fr/fpottier/listz/issues

---
:camel: Pull-request generated by opam-publish v2.3.0