### PR TITLE
Package rocq-listz.20260415

### DIFF
--- a/released/packages/rocq-listz/rocq-listz.20260415/opam
+++ b/released/packages/rocq-listz/rocq-listz.20260415/opam
@@ -1,0 +1,30 @@
+
+opam-version: "2.0"
+synopsis: "A Rocq library of lists with indices in Z"
+maintainer: "François Pottier <francois.pottier@inria.fr>"
+authors: "François Pottier <francois.pottier@inria.fr>"
+homepage: "https://gitlab.inria.fr/fpottier/listz"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/listz/"
+bug-reports: "https://gitlab.inria.fr/fpottier/listz/issues"
+license: "LGPL-2.1-only"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@install" ]
+]
+tags: [
+  "date:2026-04-15"
+  "logpath:listz"
+]
+depends: [
+  "rocq-core" { (>= "9.1") }
+  "rocq-stdlib"
+  "rocq-stdpp" { (>= "1.13.0") }
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/listz/-/archive/20260415/archive.tar.gz"
+  checksum: [
+    "md5=0f08c36d8ec39de2d06bef957f174dca"
+    "sha512=5644b1cd209e45ae6e179504dc06210834acd52338851e998074bd678738a5d20320abdd973f6a0a54f63d0e4c04519dbe7413058c6e09bf46967c1ab5f20a79"
+  ]
+}


### PR DESCRIPTION
### `rocq-listz.20260415`
A Rocq library of lists with indices in Z



---
* Homepage: https://gitlab.inria.fr/fpottier/listz
* Source repo: git+https://gitlab.inria.fr/fpottier/listz/
* Bug tracker: https://gitlab.inria.fr/fpottier/listz/issues

---
:camel: Pull-request generated by opam-publish v2.3.0