### PR TITLE
Package rocq-listz.20260415

### DIFF
--- a/released/packages/rocq-listz/rocq-listz.20260415/opam
+++ b/released/packages/rocq-listz/rocq-listz.20260415/opam
@@ -1,0 +1,31 @@
+
+opam-version: "2.0"
+synopsis: "A Rocq library of lists with indices in Z"
+maintainer: "François Pottier <francois.pottier@inria.fr>"
+authors: "François Pottier <francois.pottier@inria.fr>"
+homepage: "https://gitlab.inria.fr/fpottier/listz"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/listz/"
+bug-reports: "https://gitlab.inria.fr/fpottier/listz/issues"
+license: "LGPL-2.1-only"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs "@install" ]
+]
+tags: [
+  "date:2026-04-15"
+  "logpath:listz"
+]
+depends: [
+  "rocq-core" { (>= "9.1") }
+  "rocq-stdlib"
+  "rocq-stdpp" { (>= "1.13.0") }
+  "dune" { >= "3.21" }
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/listz/-/archive/20260415/archive.tar.gz"
+  checksum: [
+    "md5=9e52d91cafc45c6b4a5186b1a9b93fce"
+    "sha512=f13b6e2a7d2192dc0732b18f2d2115d17501fca40368ebf0a7e9fabd62958a3fd74a49519020ad7447160b65ae507ab191bc4bf73e90397ad2c6d373a0084a1a"
+  ]
+}


### PR DESCRIPTION
### `rocq-listz.20260415`
A Rocq library of lists with indices in Z



---
* Homepage: https://gitlab.inria.fr/fpottier/listz
* Source repo: git+https://gitlab.inria.fr/fpottier/listz/
* Bug tracker: https://gitlab.inria.fr/fpottier/listz/issues

---
:camel: Pull-request generated by opam-publish v2.3.0