### PR TITLE
rocq-marble: add the version constraint rocq-stdlib >= 9.1.

### DIFF
--- a/released/packages/rocq-marble/rocq-marble.20260421/opam
+++ b/released/packages/rocq-marble/rocq-marble.20260421/opam
@@ -16,7 +16,7 @@ tags: [
 ]
 depends: [
   "rocq-core" { (>= "9.1") }
-  "rocq-stdlib"
+  "rocq-stdlib" { (>= "9.1") }
   "rocq-equations"
   "rocq-stdpp" { (>= "1.13.0")}
   "dune" { >= "3.21" }


### PR DESCRIPTION
It does not work with rocq-stdlib 9.0.