### PR TITLE
Add rocq-read-file.dev to extra-dev

### DIFF
--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -11,8 +11,8 @@ depends: [
   "ocaml" {>= "4.09"}
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
-  "coq-core" {>= "8.18"}
-  "coq-stdlib" {>= "8.18"}
+  "coq-core" {>= "8.18" | = "dev"}
+  "coq-stdlib" {>= "8.18" | = "dev"}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -8,11 +8,11 @@ license: "MIT"
 homepage: "https://github.com/theorem-labs/rocq-read-file"
 bug-reports: "https://github.com/theorem-labs/rocq-read-file/issues"
 depends: [
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.14"}
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
-  "coq-core" {>= "8.18" | = "dev"}
-  "coq-stdlib" {>= "8.18" | = "dev"}
+  "rocq-runtime" {>= "9.0" | = "dev"}
+  "rocq-stdlib" {>= "9.0" | = "dev"}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -9,8 +9,9 @@ homepage: "https://github.com/theorem-labs/rocq-read-file"
 bug-reports: "https://github.com/theorem-labs/rocq-read-file/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & build}
   "coq-core" {>= "8.18"}
+  "coq-stdlib" {>= "8.18"}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Read files from disk into Rocq primitive values"
+description:
+  "A Rocq plugin that reads binary files into Rocq-side primitive values: byte arrays, int63 arrays, or primitive strings. Auto-nests into primitive arrays when results exceed PArray.max_length."
+maintainer: ["Jason Gross <jason@theorem.dev>"]
+authors: ["Jason Gross"]
+license: "MIT"
+homepage: "https://github.com/theorem-labs/rocq-read-file"
+bug-reports: "https://github.com/theorem-labs/rocq-read-file/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.8"}
+  "coq-core" {>= "8.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/theorem-labs/rocq-read-file.git"
+url {
+  src: "git+https://github.com/theorem-labs/rocq-read-file.git"
+}

--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -8,8 +8,9 @@ license: "MIT"
 homepage: "https://github.com/theorem-labs/rocq-read-file"
 bug-reports: "https://github.com/theorem-labs/rocq-read-file/issues"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.09"}
   "dune" {>= "3.8" & build}
+  "ppx_optcomp" {build}
   "coq-core" {>= "8.18"}
   "coq-stdlib" {>= "8.18"}
   "odoc" {with-doc}

--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
-  "rocq-runtime" {>= "9.0" | = "dev"}
+  "coq-core" {>= "9.0" | = "dev"}
   "rocq-stdlib" {>= "9.0" | = "dev"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
## Summary
- Add opam package file for `rocq-read-file.dev` in `extra-dev/packages/`
- rocq-read-file is a Rocq plugin that reads binary files from disk into Rocq primitive values (byte arrays, int63 arrays, primitive strings)
- Source repository: https://github.com/theorem-labs/rocq-read-file
- License: MIT
- Dependencies: ocaml >= 4.14, dune >= 3.8, coq-core >= 8.18

## Test plan
- [ ] Verify the opam file is well-formed via CI
- [ ] Test installing the package with `opam install rocq-read-file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)