### PR TITLE
Add rocq-read-file.dev package

### DIFF
--- a/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
+++ b/extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Read files from disk into Rocq primitive values"
+description: """
+A Rocq plugin that reads binary files into Rocq-side primitive values:
+byte arrays, int63 arrays, or primitive strings. Auto-nests into
+primitive arrays when results exceed PArray.max_length."""
+maintainer: ["Jason Gross <jason@theorem.dev>"]
+authors: ["Jason Gross"]
+license: "MIT"
+homepage: "https://github.com/theorem-labs/rocq-read-file"
+bug-reports: "https://github.com/theorem-labs/rocq-read-file/issues"
+dev-repo: "git+https://github.com/theorem-labs/rocq-read-file.git"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.8"}
+  "coq-core" {>= "8.18"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "git+https://github.com/theorem-labs/rocq-read-file.git#main"
+}


### PR DESCRIPTION
## Summary

- Add an opam package for `rocq-read-file`, a Rocq plugin that reads binary files from disk into Rocq primitive values (byte arrays, int63 arrays, primitive strings)
- Source repository: https://github.com/theorem-labs/rocq-read-file
- License: MIT

## Package details

- Package path: `extra-dev/packages/rocq-read-file/rocq-read-file.dev/opam`
- Dependencies: ocaml >= 4.14, dune >= 3.8, coq-core >= 8.18
- Build system: dune

🤖 Generated with [Claude Code](https://claude.com/claude-code)