### PR TITLE
Add upper bounds on coq for some old menhirlib versions

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
@@ -15,7 +15,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.7" }
+  "coq" { >= "8.7" & < "8.19" }
 ]
 conflicts: [
   "menhir" { != "20210310" }

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210419/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210419/opam
@@ -15,7 +15,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.7" }
+  "coq" { >= "8.7" & < "8.17" }
 ]
 conflicts: [
   "menhir" { != "20210419" }


### PR DESCRIPTION
These versions are between 20201216 (restricted to coq < 8.14) and 20210928 (coq < 8.19). Not sure which is correct for the in between versions so I picked the less restrictive one (8.19).

EDIT 20210419 failed with 8.18 and 8.17

cc @fpottier 