### PR TITLE
Add rocq-stdlib dependency to coq-record-update 0.3.4-0.3.6

### DIFF
--- a/released/packages/coq-record-update/coq-record-update.0.3.4/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.4/opam
@@ -17,6 +17,7 @@ build: [make "-j%{jobs}%" "NO_TEST=1"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.14" & < "9.1~") | (= "dev")}
+  "coq" {< "9.0"} | "rocq-stdlib"
 ]
 
 tags: [

--- a/released/packages/coq-record-update/coq-record-update.0.3.5/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.5/opam
@@ -17,6 +17,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.14" & < "9.1") | (= "dev")}
+  "coq" {< "9.0"} | "rocq-stdlib"
 ]
 
 tags: [

--- a/released/packages/coq-record-update/coq-record-update.0.3.6/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.6/opam
@@ -17,6 +17,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.14" & < "9.2") | (= "dev")}
+  "coq" {< "9.0"} | "rocq-stdlib"
 ]
 
 tags: [


### PR DESCRIPTION
## Summary
- Versions 0.3.4, 0.3.5, and 0.3.6 of coq-record-update permit coq >= 9.0, where the standard library is shipped separately as `rocq-stdlib`
- Adds `"coq" {< "9.0"} | "rocq-stdlib"` to each so the stdlib is available when building with coq 9.0+

## Test plan
- [ ] Verify opam lint passes on the modified files
- [ ] Confirm the packages install correctly with coq 9.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)