### PR TITLE
Add rocq-print-assumptions-json.dev

### DIFF
--- a/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
+++ b/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Structured JSON output for Print Assumptions"
+description:
+  "A Rocq plugin providing variants of Print Assumptions that output results as JSON (compact or pretty-printed) or JSONL, for programmatic consumption."
+maintainer: ["Jason Gross <jason@theorem.dev>"]
+authors: ["Jason Gross"]
+license: "MIT"
+homepage: "https://github.com/theorem-labs/rocq-structured-output-print-assumptions"
+bug-reports: "https://github.com/theorem-labs/rocq-structured-output-print-assumptions/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.8" & build}
+  "ppx_optcomp" {build}
+  "coq-core" {>= "9.0" | = "dev"}
+  "rocq-stdlib" {>= "9.0" | = "dev"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/theorem-labs/rocq-structured-output-print-assumptions.git"
+url {
+  src: "git+https://github.com/theorem-labs/rocq-structured-output-print-assumptions.git"
+}

--- a/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
+++ b/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
   "rocq-core" {>= "9.0" | = "dev"}
+  "rocq-stdlib" {with-test & (>= "9.0" | = "dev")}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
+++ b/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
   "coq-core" {>= "9.0" | = "dev"}
-  "rocq-stdlib" {>= "9.0" | = "dev"}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
+++ b/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
@@ -12,7 +12,8 @@ depends: [
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
   "rocq-core" {>= "9.0" | = "dev"}
-  "rocq-stdlib" {with-test & (>= "9.0" | = "dev")}
+  "coq-core" {>= "9.0" | = "dev"}
+  "rocq-stdlib" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
+++ b/extra-dev/packages/rocq-print-assumptions-json/rocq-print-assumptions-json.dev/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.8" & build}
   "ppx_optcomp" {build}
-  "coq-core" {>= "9.0" | = "dev"}
+  "rocq-core" {>= "9.0" | = "dev"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
## Summary
- Adds `rocq-print-assumptions-json.dev` to `extra-dev/packages`
- A Rocq plugin providing structured JSON output variants of `Print Assumptions` (compact JSON, pretty-printed JSON, JSONL)
- Supports Rocq 9.0, 9.1, 9.2, and dev
- Source: https://github.com/theorem-labs/rocq-structured-output-print-assumptions