### PR TITLE
rocq-mathcomp-algebra now depends on rocq-micromega-plugin

### DIFF
--- a/extra-dev/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.dev/opam
@@ -12,6 +12,7 @@ install: [ make "-C" "algebra" "install" ]
 depends: [
   "rocq-mathcomp-order" { = version }
   "rocq-mathcomp-finite-group" { = version }
+  "rocq-micromega-plugin" { >= "1.0.0" }
 ]
 
 tags: [


### PR DESCRIPTION
Following https://github.com/math-comp/math-comp/pull/1456