### PR TITLE
MetaRocq 1.5.1 for Rocq 9.2

### DIFF
--- a/released/packages/rocq-metarocq-common/rocq-metarocq-common.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-common/rocq-metarocq-common.1.5.1+9.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "common"]
+]
+install: [
+  [make "-C" "common" "install"]
+]
+depends: [
+  "rocq-metarocq-utils" {= version}
+]
+synopsis: "The common library of Template Rocq and PCUIC"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-erasure-plugin/rocq-metarocq-erasure-plugin.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-erasure-plugin/rocq-metarocq-erasure-plugin.1.5.1+9.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "erasure-plugin"]
+]
+install: [
+  [make "-C" "erasure-plugin" "install"]
+]
+depends: [
+  "rocq-metarocq-template-pcuic" {= version}
+  "rocq-metarocq-erasure" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The Erasure module provides a complete specification of Rocq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-erasure/rocq-metarocq-erasure.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-erasure/rocq-metarocq-erasure.1.5.1+9.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "erasure"]
+]
+install: [
+  [make "-C" "erasure" "install"]
+]
+depends: [
+  "rocq-metarocq-safechecker" {= version}
+  "rocq-metarocq-template-pcuic" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The Erasure module provides a complete specification of Rocq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-pcuic/rocq-metarocq-pcuic.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-pcuic/rocq-metarocq-pcuic.1.5.1+9.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "pcuic"]
+]
+install: [
+  [make "-C" "pcuic" "install"]
+]
+depends: [
+  "rocq-metarocq-common" {= version}
+]
+synopsis: "A type system equivalent to Rocq's and its metatheory"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The PCUIC module provides a cleaned-up specification of Rocq's typing algorithm along
+with a certified typechecker for it. This module includes the standard metatheory of
+PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-quotation/rocq-metarocq-quotation.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-quotation/rocq-metarocq-quotation.1.5.1+9.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "quotation"]
+]
+install: [
+  [make "-C" "quotation" "install"]
+]
+depends: [
+  "rocq-metarocq-template" {= version}
+  "rocq-metarocq-pcuic" {= version}
+  "rocq-metarocq-template-pcuic" {= version}
+]
+synopsis: "Gallina quotation functions for Template Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The Quotation module is geared at providing functions `□T → □□T` for
+`□T := Ast.term` (currently implemented) and for `□T := { t : Ast.term
+& Σ ;;; [] |- t : T }` (still in the works).  Currently `Ast.term →
+Ast.term` and `(Σ ;;; [] |- t : T) → Ast.term` functions are provided
+for Template and PCUIC terms, in `MetaRocq.Quotation.ToTemplate.All`
+and `MetaRocq.Quotation.ToPCUIC.All`.  Proving well-typedness is still
+a work in progress.
+
+Ultimately the goal of this development is to prove that `□` is a lax monoidal
+semicomonad (a functor with `cojoin : □T → □□T` that codistributes over `unit`
+and `×`), which is sufficient for proving Löb's theorem.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-safechecker-plugin/rocq-metarocq-safechecker-plugin.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-safechecker-plugin/rocq-metarocq-safechecker-plugin.1.5.1+9.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "safechecker-plugin"]
+]
+install: [
+  [make "-C" "safechecker-plugin" "install"]
+]
+depends: [
+  "rocq-metarocq-template-pcuic" {= version}
+  "rocq-metarocq-safechecker" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The Erasure module provides a complete specification of Rocq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-safechecker/rocq-metarocq-safechecker.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-safechecker/rocq-metarocq-safechecker.1.5.1+9.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "safechecker"]
+]
+install: [
+  [make "-C" "safechecker" "install"]
+]
+depends: [
+  "rocq-metarocq-pcuic" {= version}
+]
+synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The SafeChecker modules provides a correct implementation of
+weak-head reduction, conversion and typechecking of Rocq definitions and global environments.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-template-pcuic/rocq-metarocq-template-pcuic.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-template-pcuic/rocq-metarocq-template-pcuic.1.5.1+9.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "template-pcuic"]
+]
+install: [
+  [make "-C" "template-pcuic" "install"]
+]
+depends: [
+  "rocq-metarocq-template" {= version}
+  "rocq-metarocq-pcuic" {= version}
+]
+synopsis: "Translations between Template Rocq and PCUIC and proofs of correctness"
+description: """
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-template/rocq-metarocq-template.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-template/rocq-metarocq-template.1.5.1+9.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "template-rocq"]
+]
+install: [
+  [make "-C" "template-rocq" "install"]
+]
+depends: [
+  "rocq-metarocq-common" {= version}
+]
+synopsis: "A quoting and unquoting library for Rocq in Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+Template Rocq is a quoting library for Rocq. It takes Rocq terms and
+constructs a representation of their syntax tree as a Rocq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Rocq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaRocq/MTac.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-translations/rocq-metarocq-translations.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-translations/rocq-metarocq-translations.1.5.1+9.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "translations"]
+]
+install: [
+  [make "-C" "translations" "install"]
+]
+depends: [
+  "rocq-metarocq-template" {= version}
+]
+synopsis: "Translations built on top of MetaRocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The Translations modules provides implementation of standard translations
+from type theory to type theory, e.g. parametricity and the `cross-bool`
+translation that invalidates functional extensionality.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq-utils/rocq-metarocq-utils.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq-utils/rocq-metarocq-utils.1.5.1+9.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["bash" "./configure.sh"]
+  [make "-j" "%{jobs}%" "utils"]
+]
+install: [
+  [make "-C" "utils" "install"]
+]
+depends: [
+  "stdlib-shims"
+  "rocq-core" { >= "9.2~" & < "9.3~" }
+  "rocq-stdlib" { >= "9.1~" & != "9.1.dev" & < "10" }
+  "rocq-equations" { >= "1.3.2" }
+  "coq-ext-lib" {>= "0.12"}
+]
+synopsis: "The utility library of Template Rocq and PCUIC"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}

--- a/released/packages/rocq-metarocq/rocq-metarocq.1.5.1+9.2/opam
+++ b/released/packages/rocq-metarocq/rocq-metarocq.1.5.1+9.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metarocq.github.io/metarocq"
+dev-repo: "git+https://github.com/MetaRocq/metarocq.git#main"
+bug-reports: "https://github.com/MetaRocq/metarocq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Danil Annenkov <danil.v.annenkov@gmail.com>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Jason Gross <jgross@mit.edu>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Meven Lennon-Bertrand <Meven.Bertrand@univ-nantes.fr>"
+          "Kenji Maillard <kenji.maillard@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Jakob Botsch Nielsen <Jakob.botsch.nielsen@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+depends: [
+  "rocq-metarocq-safechecker-plugin" {= version}
+  "rocq-metarocq-erasure-plugin" {= version}
+  "rocq-metarocq-translations" {= version}
+  "rocq-metarocq-quotation" {= version}
+]
+build: [
+  ["bash" "./configure.sh" ] {with-test}
+  [make "-C" "examples" ] {with-test}
+  [make "-C" "test-suite" ] {with-test}
+]
+synopsis: "A meta-programming framework for Rocq"
+description: """
+MetaRocq is a meta-programming framework for Rocq.
+
+The meta-package includes the template-rocq library,
+the PCUIC development including a verified equivalence between Rocq and PCUIC,
+a safe type checker and verified erasure for PCUIC and example translations.
+
+See individual packages for more detailed descriptions.
+"""
+url {
+  src: "https://github.com/MetaRocq/metarocq/archive/refs/tags/v1.5.1-9.2.tar.gz"
+  checksum: "sha512=871529733be78fdf796b2e00ca8a4d0064e581cf4c64367deba6bbab1c75d5dd54b43c5031f5d896083fabaf577159c71a11f771f673ef994354074f7d67386b"
+}


### PR DESCRIPTION
ci-skip: rocq-metarocq-common.1.5.1+9.2 rocq-metarocq-erasure-plugin.1.5.1+9.2 rocq-metarocq-erasure.1.5.1+9.2 rocq-metarocq-pcuic.1.5.1+9.2 rocq-metarocq-quotation.1.5.1+9.2 rocq-metarocq-safechecker-plugin.1.5.1+9.2 rocq-metarocq-safechecker.1.5.1+9.2 rocq-metarocq-template-pcuic.1.5.1+9.2 rocq-metarocq-template.1.5.1+9.2 rocq-metarocq-translations.1.5.1+9.2 rocq-metarocq-utils.1.5.1+9.2