### PR TITLE
Package rocq-navi.0.5.0

### DIFF
--- a/released/packages/rocq-navi/rocq-navi.0.5.0/opam
+++ b/released/packages/rocq-navi/rocq-navi.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Yoshihiro Imai<y.imai@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/rocqnavi"
+dev-repo: "git+https://github.com/yoshihiro503/rocqnavi.git"
+bug-reports: "https://github.com/affeldt-aist/rocqnavi/issues"
+
+license: "GPL-2.0-or-later"
+synopsis: "Extension of coq2html Document Generator"
+
+description: """
+Extension of coq2html Document Generator"""
+
+build: [make]
+install: [make "BINDIR=%{bin}%" "install"]
+depends: [
+  "ocaml" {>= "4.14"}
+  "ocamlfind"
+  "dune-glob" # Parsing glob syntax like "*_unnamed_mixin_*"
+  "yojson"
+  "coq-lsp" {with-test}
+  "rocq-hierarchy-builder" {with-test}
+]
+
+tags: [
+  "category:Tools/Document Generator"
+  "keyword:document"
+  "keyword:html"
+  "logpath:"
+]
+authors: [
+  "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+  "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+  "Yoshihiro Imai <y.imai@aist.go.jp>"
+]
+url {
+  src:
+    "https://github.com/affeldt-aist/rocqnavi/archive/refs/tags/rocqnavi.0.5.0.tar.gz"
+  checksum: [
+    "md5=9e8c54ef863b048d03556a1690a0da27"
+    "sha512=aba4e0b1eb93d94b25b508dcd9fff287f163c5cb32680c8152af5b48686f595fca6498ff0cd3bded4694c8a8ea1a2ecae80181d8cafcd5e48bd4e9c1f97887e4"
+  ]
+}
+


### PR DESCRIPTION
### `rocq-navi.0.5.0`
Extension of coq2html Document Generator
Extension of coq2html Document Generator



---
* Homepage: https://github.com/affeldt-aist/rocqnavi
* Source repo: git+https://github.com/yoshihiro503/rocqnavi.git
* Bug tracker: https://github.com/affeldt-aist/rocqnavi/issues

---
:camel: Pull-request generated by opam-publish v3.0.0