### PR TITLE
2 packages from math-comp/hierarchy-builder at 1.10.3

### DIFF
--- a/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.10.3/opam
+++ b/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.10.3/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+synopsis: "Compatibility package for rocq-hierarchy-builder"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: ["Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi"]
+license: "MIT"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+depends: [
+  "coq-core"
+  "rocq-hierarchy-builder" {= version}
+]
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+url {
+  src:
+    "https://github.com/math-comp/hierarchy-builder/releases/download/v1.10.3/hierarchy-builder-1.10.3.tar.gz"
+  checksum: [
+    "md5=483fa6b055841255424923592b185dc2"
+    "sha512=d9a84616bf77215585cf1f60c53daa49de7247bc66eee8ab3808442f94bca8559189572757be94fb6a79589b46f381fdb260eefeb5e99a5d454d23447cc4b5ed"
+  ]
+}

--- a/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.3/opam
+++ b/released/packages/rocq-hierarchy-builder/rocq-hierarchy-builder.1.10.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "High level commands to declare and evolve a hierarchy based on packed classes"
+description: """\
+Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
+hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
+and abbreviation that let the hierarchy developer describe an actual interface for their library.
+Behind that interface the developer can provide appropriate code to ensure retro compatibility."""
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: ["Cyril Cohen" "Kazuhiko Sakaguchi" "Enrico Tassi"]
+license: "MIT"
+tags: "logpath:HB"
+homepage: "https://github.com/math-comp/hierarchy-builder"
+bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
+depends: [
+  "rocq-core" {(>= "9.0" & < "9.3~") | = "dev"}
+  "rocq-elpi" {>= "3" | = "dev"}
+]
+conflicts: [
+  "coq-hierarchy-builder" {< "1.9~"}
+  "coq-hierarchy-builder-shim"
+]
+build: [
+  [make "build"]
+  [make "test-suite"] {with-test & rocq-core:installed}
+]
+install: [make "install"]
+depexts: ["wdiff"] {os-family = "debian" & with-test}
+dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
+url {
+  src:
+    "https://github.com/math-comp/hierarchy-builder/releases/download/v1.10.3/hierarchy-builder-1.10.3.tar.gz"
+  checksum: [
+    "md5=483fa6b055841255424923592b185dc2"
+    "sha512=d9a84616bf77215585cf1f60c53daa49de7247bc66eee8ab3808442f94bca8559189572757be94fb6a79589b46f381fdb260eefeb5e99a5d454d23447cc4b5ed"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`coq-hierarchy-builder.1.10.3`: Compatibility package for rocq-hierarchy-builder
-`rocq-hierarchy-builder.1.10.3`: High level commands to declare and evolve a hierarchy based on packed classes



---
* Homepage: https://github.com/math-comp/hierarchy-builder
* Source repo: git+https://github.com/math-comp/hierarchy-builder
* Bug tracker: https://github.com/math-comp/hierarchy-builder/issues

---
:camel: Pull-request generated by opam-publish v2.0.3