### PR TITLE
Add coq-rupicola.dev tracking rupicola master

### DIFF
--- a/extra-dev/packages/coq-rupicola/coq-rupicola.dev/opam
+++ b/extra-dev/packages/coq-rupicola/coq-rupicola.dev/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: [
+  "Clément Pit-Claudel <clement.pitclaudel@live.com>"
+  "Jade Philipoom"
+  "Dustin Jamner"
+  "Andres Erbsen"
+  "Adam Chlipala"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rupicola"
+bug-reports: "https://github.com/mit-plv/rupicola/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "9.0~"}
+  "coq-bedrock2" {= "dev"}
+]
+dev-repo: "git+https://github.com/mit-plv/rupicola.git"
+synopsis: "Gallina to imperative code compilation, currently in design phase"
+tags: ["logpath:Rupicola"]
+url {
+  src: "git+https://github.com/mit-plv/rupicola.git#master"
+}


### PR DESCRIPTION
Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

Adds `coq-rupicola.dev` to `extra-dev`, tracking [rupicola](https://github.com/mit-plv/rupicola) `master`.

The package mirrors the released `coq-rupicola` entries (same build/install invocation with `EXTERNAL_DEPENDENCIES=1`, verified to still match rupicola master's Makefile targets), with the dependency switched from an exact released `coq-bedrock2` to `coq-bedrock2 {= "dev"}`, since rupicola master tracks bedrock2 master (vendored as a submodule when not building with external dependencies).

`opam lint` passes on the new file.

**Note on CI:** the `opam-build:4.09.0` lane fails on current master independently of this package: on OCaml 4.09 the solver resolves `coq {>= "9.0~"}` to `rocq-runtime.9.0.dev`, which no longer builds with dune ≥ 3.24 (`(using coq 0.8)` was deleted from the dune language). #3776 fixes that by capping dune on the affected core-dev packages; this PR should go green once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
