### PR TITLE
core-dev: cap dune < 3.24 for dev packages built from (using coq) trees

### DIFF
--- a/core-dev/packages/coq-core/coq-core.8.17.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.17.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.18.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.18.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.19.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.19.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.8.20.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.20.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6.1"}
+  "dune" {>= "3.6.1" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/coq-core/coq-core.9.0.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.9.0.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coq-core/coq-core.9.1.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.9.1.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coq-core/coq-core.9.2.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.9.2.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coq-stdlib/coq-stdlib.8.17.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.8.17.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
 ]
 build: [

--- a/core-dev/packages/coq-stdlib/coq-stdlib.8.18.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.8.18.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
 ]
 build: [

--- a/core-dev/packages/coq-stdlib/coq-stdlib.8.19.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.8.19.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coq-stdlib/coq-stdlib.8.20.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.8.20.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.6" & < "3.24"}
   "coq-core" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coq/coq.8.14.dev/opam
+++ b/core-dev/packages/coq/coq.8.14.dev/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/core-dev/packages/coq/coq.8.15.dev/opam
+++ b/core-dev/packages/coq/coq.8.15.dev/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/core-dev/packages/coq/coq.8.16.dev/opam
+++ b/core-dev/packages/coq/coq.8.16.dev/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.11"}
 ]

--- a/core-dev/packages/coq/coq.8.17.dev/opam
+++ b/core-dev/packages/coq/coq.8.17.dev/opam
@@ -18,7 +18,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
   "coqide-server" {= version}

--- a/core-dev/packages/coq/coq.8.18.dev/opam
+++ b/core-dev/packages/coq/coq.8.18.dev/opam
@@ -18,7 +18,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
   "coqide-server" {= version}

--- a/core-dev/packages/coq/coq.8.19.dev/opam
+++ b/core-dev/packages/coq/coq.8.19.dev/opam
@@ -18,7 +18,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
   "coqide-server" {= version}

--- a/core-dev/packages/coq/coq.8.20.dev/opam
+++ b/core-dev/packages/coq/coq.8.20.dev/opam
@@ -18,7 +18,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.6" & < "3.24"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
   "coqide-server" {= version}

--- a/core-dev/packages/coq/coq.9.0.dev/opam
+++ b/core-dev/packages/coq/coq.9.0.dev/opam
@@ -7,7 +7,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "coq-core" {= version}
   "coq-stdlib"
   "coqide-server" {= version}

--- a/core-dev/packages/coqide-server/coqide-server.8.17.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.8.17.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
 ]
 build: [

--- a/core-dev/packages/coqide-server/coqide-server.8.18.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.8.18.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
 ]
 build: [

--- a/core-dev/packages/coqide-server/coqide-server.8.19.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.8.19.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "coq-core" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coqide-server/coqide-server.8.20.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.8.20.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.6" & < "3.24"}
   "coq-core" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coqide-server/coqide-server.9.0.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.9.0.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coqide-server/coqide-server.9.1.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.9.1.dev/opam
@@ -17,7 +17,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coqide-server/coqide-server.9.2.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.9.2.dev/opam
@@ -19,7 +19,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/coqide/coqide.8.14.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.14.dev/opam
@@ -15,7 +15,7 @@ using the Coq proof assistant.
 depends: [
   "coq" {= version}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "lablgtk3-sourceview3"
   "conf-adwaita-icon-theme"

--- a/core-dev/packages/coqide/coqide.8.15.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.15.dev/opam
@@ -15,7 +15,7 @@ using the Coq proof assistant.
 depends: [
   "coq" {= version}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "lablgtk3-sourceview3"
   "conf-adwaita-icon-theme"

--- a/core-dev/packages/coqide/coqide.8.16.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.16.dev/opam
@@ -15,7 +15,7 @@ using the Coq proof assistant.
 depends: [
   "coq" {= version}
   "ocamlfind" {>= "1.8.1"}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "lablgtk3-sourceview3" {>= "3.1.2"}
   "conf-adwaita-icon-theme"

--- a/core-dev/packages/coqide/coqide.8.17.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.17.dev/opam
@@ -15,7 +15,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocamlfind" {build}
   "conf-findutils" {build}
   "conf-adwaita-icon-theme"

--- a/core-dev/packages/rocq-core/rocq-core.9.0.dev/opam
+++ b/core-dev/packages/rocq-core/rocq-core.9.0.dev/opam
@@ -22,7 +22,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/rocq-core/rocq-core.9.1.dev/opam
+++ b/core-dev/packages/rocq-core/rocq-core.9.1.dev/opam
@@ -22,7 +22,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/rocq-core/rocq-core.9.2.dev/opam
+++ b/core-dev/packages/rocq-core/rocq-core.9.2.dev/opam
@@ -24,7 +24,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "odoc" {with-doc}
 ]

--- a/core-dev/packages/rocq-devtools/rocq-devtools.9.1.dev/opam
+++ b/core-dev/packages/rocq-devtools/rocq-devtools.9.1.dev/opam
@@ -21,7 +21,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "rocq-runtime" {= version}
   "yojson"
   "camlzip"

--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.0.dev/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.0.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.1.dev/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.1.dev/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os != "windows")}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.2.dev/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.2.dev/opam
@@ -27,7 +27,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}

--- a/core-dev/packages/rocqide/rocqide.9.0.dev/opam
+++ b/core-dev/packages/rocqide/rocqide.9.0.dev/opam
@@ -15,7 +15,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocamlfind" {build}
   "conf-findutils" {build}
   "conf-adwaita-icon-theme"

--- a/core-dev/packages/rocqide/rocqide.9.1.dev/opam
+++ b/core-dev/packages/rocqide/rocqide.9.1.dev/opam
@@ -15,7 +15,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocamlfind" {build}
   "conf-findutils" {build}
   "conf-adwaita-icon-theme"


### PR DESCRIPTION
Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

Dune 3.24 deleted the `coq` dune-language extension (replaced by `(using rocq ...)`). The branches and tags behind the `core-dev` packages up to 9.2 still have `(using coq 0.x)` in their `dune-project`, so any of them built with dune ≥ 3.24 now fails immediately:

```
[ERROR] The compilation of rocq-runtime.9.0.dev failed at "dune subst".
File "dune-project", line 8, characters 0-15:
8 | (using coq 0.8)
Error: Extension coq was deleted in the 3.24 version of the dune language
Hint: The Coq Build Language has been replaced by the Rocq Build Language.
Use (using rocq <version>) instead.
```

This currently breaks extra-dev CI lanes whose OCaml version steers the solver to one of these packages — first seen on the `opam-build:4.09.0` lane of #3775, where `coq {>= "9.0~"}` resolves to `rocq-runtime.9.0.dev` (9.1+ need a newer OCaml).

This PR caps `dune {< "3.24"}` on the 39 core-dev **dev** packages whose source branches predate the `rocq` extension (families `coq`, `coq-core`, `coq-stdlib`, `coqide`, `coqide-server`, `rocq-runtime`, `rocq-core`, `rocq-devtools`, `rocqide`, versions 8.14–9.2). The 9.3 and master-based `dev` packages already use `(using rocq ...)` (checked on the `v9.3` and `master` branches) and are left unconstrained.

The `+rc` packages from the same trees are equally affected by the dune incompatibility, but are left untouched here: their tag-archive checksums no longer match upstream (GitHub regenerated the tarballs at some point), so they are uninstallable anyway, and touching them makes `opam-lint`'s upstream check fail the pipeline (error 60 on `coq-core.8.17+rc1` in the first run of this PR). Fixing those checksums is a separate cleanup.

An alternative would be backporting `(using rocq ...)` to the still-maintained release branches, but that only helps versions that get a new tag/branch update, and the archive needs the old tags to keep building regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
