### PR TITLE
:hammer::adhesive_bandage: Patch Build coq-elpi.3.2.0 for coq 8

### DIFF
--- a/released/packages/rocq-elpi/rocq-elpi.3.2.0/files/fix-coq8-build.patch
+++ b/released/packages/rocq-elpi/rocq-elpi.3.2.0/files/fix-coq8-build.patch
@@ -1,0 +1,12 @@
+diff --git a/src/dune.in b/src/dune.in
+index 5333dfa3..a82d03de 100644
+--- a/src/dune.in
++++ b/src/dune.in
+@@ -2,6 +2,7 @@
+  (name elpi_plugin)
+  (public_name rocq-elpi.elpi)
+  (synopsis "Elpi")
++ (modes byte native)
+  (flags :standard -w -27)
+  (preprocessor_deps rocq_elpi_config.mlh)
+  (preprocess

--- a/released/packages/rocq-elpi/rocq-elpi.3.2.0/opam
+++ b/released/packages/rocq-elpi/rocq-elpi.3.2.0/opam
@@ -41,8 +41,12 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+extra-files: [
+  "fix-coq8-build.patch"
+  "sha256=f937fb50ad99aa719b3c055d08585230def5aec3e2edc50d2dfbbb6578d61085"
+]
 patches: [
-  "files/fix-coq8-build.patch"
+  "fix-coq8-build.patch"
 ]
 dev-repo: "git+https://github.com/LPCIC/coq-elpi.git"
 url {

--- a/released/packages/rocq-elpi/rocq-elpi.3.2.0/opam
+++ b/released/packages/rocq-elpi/rocq-elpi.3.2.0/opam
@@ -41,6 +41,9 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+patches: [
+  "files/fix-coq8-build.patch"
+]
 dev-repo: "git+https://github.com/LPCIC/coq-elpi.git"
 url {
   src:


### PR DESCRIPTION
This fix resolves an issue where coq-elpi causes a build error in Coq8.

I submitted a pull request to coq-elpi, but since coq-elpi no longer supports Coq8, I decided to post the patch here instead.
* https://github.com/LPCIC/coq-elpi/pull/1073
* https://github.com/LPCIC/coq-elpi/issues/1061