### PR TITLE
Fix coqprime generator dependencies

### DIFF
--- a/extra-dev/packages/coq-coqprime-generator/coq-coqprime-generator.dev/opam
+++ b/extra-dev/packages/coq-coqprime-generator/coq-coqprime-generator.dev/opam
@@ -31,7 +31,8 @@ install: [
 ]
 depends: [
   "ocaml"
-  "num"
+  "ocamlfind"
+  "zarith"
   "conf-gmp"
   "gmp-ecm"
 ]


### PR DESCRIPTION
The dev metadata for `coq-coqprime-generator` declares `num`, but the
generator's build invokes `ocamlfind query zarith`, links `zarith.cma`,
and opens `Big_int_Z`.

This caused the `rocq-dev-testing` build to fail with:

```
ocamlfind: Package `zarith' not found
File "parser.ml", line 3, characters 5-14:
3 | open Big_int_Z
         ^^^^^^^^^
Error: Unbound module Big_int_Z
```

Replace the unused `num` dependency with the direct build dependencies
`ocamlfind` and `zarith`. This matches the corresponding dependencies
already present in the released package metadata.

Validation:

- `opam lint --switch=rocq-dev-testing extra-dev/packages/coq-coqprime-generator/coq-coqprime-generator.dev/opam`
- clean local build under `opam exec --switch=rocq-dev-testing`, producing
  `pocklington`, `firstprimes`, and `o2v`

*Authorship note: this was researched and written by an AI coding agent (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is posted from this account.*


> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*
