### PR TITLE
Fix coq-rocqnavi.dev dependencies

### DIFF
--- a/extra-dev/packages/coq-rocqnavi/coq-rocqnavi.dev/opam
+++ b/extra-dev/packages/coq-rocqnavi/coq-rocqnavi.dev/opam
@@ -15,6 +15,9 @@ build: [make]
 install: [make "BINDIR=%{bin}%" "install"]
 depends: [
   "ocaml" {>= "4.14"}
+  "ocamlfind"
+  "dune-glob" # Parsing glob syntax like "*_unnamed_mixin_*"
+  "yojson"
 ]
 
 tags: [


### PR DESCRIPTION
The development package builds with `ocamlfind` and directly imports both `Dune_glob` and `Yojson`, but its metadata currently declares only OCaml. Add the three dependencies already declared by the project's own `rocq-navi.opam`.

Without these declarations, a clean switch fails at the first compilation command:

```text
ocamlfind: Package `dune-glob' not found
```

Validation: `opam lint extra-dev/packages/coq-rocqnavi/coq-rocqnavi.dev/opam` passes.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*