### PR TITLE
Fix _CoqProject paths for migrated contribs

### DIFF
--- a/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
@@ -3,7 +3,7 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/coq-contribs/coqoban"
 license: "LGPL 2"
 build: [
-  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]

--- a/extra-dev/packages/coq-generic-environments/coq-generic-environments.dev/opam
+++ b/extra-dev/packages/coq-generic-environments/coq-generic-environments.dev/opam
@@ -3,7 +3,7 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/coq-contribs/generic-environments"
 license: "LGPL"
 build: [
-  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]

--- a/extra-dev/packages/coq-hoare-tut/coq-hoare-tut.dev/opam
+++ b/extra-dev/packages/coq-hoare-tut/coq-hoare-tut.dev/opam
@@ -3,7 +3,7 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/coq-contribs/hoare-tut"
 license: "GNU LGPL"
 build: [
-  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
   [make "install"]
 ]

--- a/extra-dev/packages/coq-ipc/coq-ipc.dev/opam
+++ b/extra-dev/packages/coq-ipc/coq-ipc.dev/opam
@@ -3,7 +3,7 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/coq-contribs/ipc"
 license: "Proprietary"
 build: [
-  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]

--- a/extra-dev/packages/coq-paradoxes/coq-paradoxes.dev/opam
+++ b/extra-dev/packages/coq-paradoxes/coq-paradoxes.dev/opam
@@ -3,7 +3,7 @@ maintainer: "dev@clarus.me"
 homepage: "https://github.com/coq-contribs/paradoxes"
 license: "LGPL 2"
 build: [
-  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]


### PR DESCRIPTION
Five extra-dev packages have migrated their project files from the legacy `Make` format to `_CoqProject`, but their opam build instructions still pass `-f Make` to `coq_makefile`. Current Rocq therefore fails immediately with `Make: No such file or directory`.

This updates those build instructions to use the project file present in each source repository.

Validation:
- `coq_makefile -f _CoqProject -o Makefile` succeeds for all five packages with Rocq dev.
- Full local builds succeed for coq-coqoban, coq-generic-environments, and coq-paradoxes.
- coq-hoare-tut and coq-ipc proceed past makefile generation and expose separate source-compatibility failures.
- `opam lint` reports only pre-existing warnings.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*