### PR TITLE
coq-rupicola: declare conflict-class ["coq-rupicola"]

### DIFF
--- a/extra-dev/packages/coq-rupicola/coq-rupicola.dev/opam
+++ b/extra-dev/packages/coq-rupicola/coq-rupicola.dev/opam
@@ -19,6 +19,9 @@ depends: [
   "coq" {>= "9.0~"}
   "coq-bedrock2" {= "dev"}
 ]
+conflict-class: [
+  "coq-rupicola"
+]
 dev-repo: "git+https://github.com/mit-plv/rupicola.git"
 synopsis: "Gallina to imperative code compilation, currently in design phase"
 tags: ["logpath:Rupicola"]


### PR DESCRIPTION
`coq-fiat-crypto-with-bedrock` declares

```
conflict-class: [ "coq-fiat-crypto" "coq-coqutil" "coq-bedrock2" "coq-rupicola" ]
```

because it is a monolithic build that vendors all four. Three of those four
name the class back: `coq-fiat-crypto`, `coq-coqutil` and `coq-bedrock2` each
declare their own `conflict-class`. `coq-rupicola` does not, so the claim on
`"coq-rupicola"` is one-sided.

`conflict-class` is symmetric-by-membership — it constrains the set of
installed packages that *declare* the class — so a one-sided declaration
protects nothing, and opam will happily install `coq-rupicola` alongside
`coq-fiat-crypto-with-bedrock`.

The collision is real, not hypothetical. In a switch with the monolith
installed, its manifest contains **72** `lib/coq/user-contrib/Rupicola/…`
paths — exactly the files `coq-rupicola` installs:

```
$ grep -c 'user-contrib/Rupicola' \
    ~/.opam/<switch>/.opam-switch/install/coq-fiat-crypto-with-bedrock.changes
72
```

Whichever installs second overwrites the other's `.vo` files. The overwritten
files load fine on their own, so the error does not appear at install time; it
surfaces later and elsewhere as

```
Compiled library ... makes inconsistent assumptions over library Rupicola....
```

We have the same failure live in one of our switches for the
`coq-compcert`/`coq-wasm` pair, which likewise declares no conflict-class on
either side, and it took a while to recognise as a packaging collision rather
than a source problem.

This adds the missing declaration, matching what `coq-bedrock2` and
`coq-coqutil` already do. `opam lint` passes.


> *Authorship note: this was researched and written by an AI coding agent
> (Anthropic Claude), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*
