### PR TITLE
Add coq-riscv.dev

### DIFF
--- a/extra-dev/packages/coq-riscv/coq-riscv.dev/opam
+++ b/extra-dev/packages/coq-riscv/coq-riscv.dev/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/riscv-coq"
+bug-reports: "https://github.com/mit-plv/riscv-coq/issues"
+license: "BSD-3-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "coq" {>= "8.18~"}
+  ("coq-coqutil" {>= "0.0.7"} | "coq-fiat-crypto-with-bedrock")
+  "coq-record-update" {>= "0.3.0"}
+]
+dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
+synopsis: "RISC-V Specification in Coq, somewhat experimental"
+tags: ["logpath:riscv"]
+url {
+  src: "git+https://github.com/mit-plv/riscv-coq.git#master"
+}

--- a/extra-dev/packages/coq-riscv/coq-riscv.dev/opam
+++ b/extra-dev/packages/coq-riscv/coq-riscv.dev/opam
@@ -11,9 +11,9 @@ build: [
 ]
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
-  "coq" {>= "8.18~"}
-  ("coq-coqutil" {>= "0.0.7"} | "coq-fiat-crypto-with-bedrock")
-  "coq-record-update" {>= "0.3.0"}
+  "coq" {>= "8.18~" | = "dev"}
+  ("coq-coqutil" {>= "0.0.7" | = "dev"} | "coq-fiat-crypto-with-bedrock")
+  "coq-record-update" {>= "0.3.0" | = "dev"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"


### PR DESCRIPTION
Adds `extra-dev/packages/coq-riscv/coq-riscv.dev/opam`, tracking `master` of https://github.com/mit-plv/riscv-coq. `coq-riscv` has releases 0.0.2–0.0.6 in `released/` but no dev version.

**Verified.** Built and installed from a clean checkout of `master` on a switch with Rocq `9.4+alpha` — 97/97 `.vo` files, `make install` clean. `From Coq Require` still resolves (only `deprecated-from-Coq`), and `coqutil` resolves from the installed library path because `EXTERNAL_DEPENDENCIES=1` suppresses the in-tree `-Q` flag for it.

**The coqutil dependency is a disjunction**, `coq-coqutil | coq-fiat-crypto-with-bedrock`, rather than a plain `coq-coqutil`. `coq-fiat-crypto-with-bedrock` vendors coqutil — it installs 393 files under `user-contrib/coqutil/` — and declares

```
conflict-class: ["coq-fiat-crypto" "coq-coqutil" "coq-bedrock2" "coq-rupicola"]
```

so it can never coexist with `coq-coqutil`. A hard `coq-coqutil` dependency would therefore make `coq-riscv` uninstallable on any switch that has `coq-fiat-crypto-with-bedrock`, even though coqutil is present and complete there. The alternative reflects the real requirement: *some* provider of the `coqutil` logical path.

`opam lint` passes, and `opam lint --normalise` round-trips the file, confirming the package-level `|` parses as intended.

A matching `coq-riscv.opam` is proposed in-repo at https://github.com/mit-plv/riscv-coq/pull/50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
