### PR TITLE
Add rocq-sail-stdpp.dev

### DIFF
--- a/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
+++ b/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis:
+  "Support library for Sail, a language for describing the instruction semantics of processors, using stdpp bitvectors"
+description: """
+The support library for instruction-set semantics generated from Sail.
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+The Sail tool can be found in main opam repository."""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+tags: [
+  "logpath:Sail"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+]
+homepage: "http://www.cl.cam.ac.uk/~pes20/sail/"
+doc: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/coq-sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "rocq-core" {>= "9.0"}
+  "rocq-stdpp-bitvector" {>= "1.13.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "sail" {!= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rems-project/coq-sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "git+https://github.com/rems-project/coq-sail.git#main"
+}

--- a/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
+++ b/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
@@ -35,7 +35,7 @@ doc: "https://github.com/rems-project/sail"
 bug-reports: "https://github.com/rems-project/coq-sail/issues"
 depends: [
   "dune" {>= "3.21"}
-  "rocq-core" {>= "9.0"}
+  "rocq-core" {= "dev"}
   "rocq-stdpp-bitvector" {>= "1.13.0"}
   "odoc" {with-doc}
 ]

--- a/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
+++ b/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
@@ -39,9 +39,6 @@ depends: [
   "rocq-stdpp-bitvector" {>= "1.13.0"}
   "odoc" {with-doc}
 ]
-conflicts: [
-  "sail" {!= version}
-]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Adds `rocq-sail-stdpp.dev`, tracking the `main` branch of
[rems-project/coq-sail](https://github.com/rems-project/coq-sail) (`main` is that
repository's default branch).

**Provenance.** The recipe is upstream's own dune-generated `rocq-sail-stdpp.opam`
with exactly two lines dropped — dune's "this file is generated" header and
`version: "0.20.2"` — and a `url` block appended. Nothing else was edited.

**No constraints were relaxed.** Upstream's in-tree opam file carries no upper
bounds at all; the `< "9.3~"` and `< "1.14.0~"` caps that the released versions in
this archive have were added here at publish time rather than coming from
upstream. So `rocq-core {>= "9.0"}` and `rocq-stdpp-bitvector {>= "1.13.0"}` are
upstream's own bounds, unmodified. (Worth noting for the second one: opam orders
`"1.13.0" < "dev"`, so a `< "1.14.0~"` cap would have excluded the
`dev.2026-…` versions that `rocq-stdpp-bitvector` publishes in the `iris-dev`
repository.)

**Verification.** `dune build -p rocq-sail-stdpp -j 8 @install` against a switch
tracking Rocq master (9.4+alpha) exits 0, with only deprecation warnings
(`implicit-create-rewrite-hint-db` and `non-boolean-if`, in `src-stdpp/State_lemmas.v`
and `src-stdpp/Hoare.v`). `opam lint` passes under the opam 2.1.2 that
`.gitlab-ci.yml` pins. I did not exercise the `opam install` path locally, so CI
here is the first test of that.

**One thing worth a maintainer's eye:** `conflicts: ["sail" {!= version}]` is
inherited verbatim from upstream. Since no `sail.dev` exists in opam-repository,
on a `.dev` package this reads as "cannot be co-installed with any released
`sail`". I kept it to stay faithful to upstream, and there is precedent for the
pattern in `extra-dev` (`menhirLib.dev`, `menhirCST.dev`, `menhirGLR.dev`,
`menhirSdk.dev`, `coq-hammer-tactics.dev`, `rocq-mathcomp-finmap.dev`,
`rocq-mathcomp-bigenough.dev`), but I am happy to drop or loosen it if you would
rather the dev package not carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b

---

**CI note.** Rebased onto master. Two successive `opam-build:4.09.0` failures here were both archive-side metadata problems in this package's dependency closure, not in `rocq-sail-stdpp.dev` itself:

1. `rocq-runtime.9.3.dev` claimed to support OCaml 4.09 while its own configure requires 4.14 — fixed in master by #3803.
2. With that gone, the solver fell back to `rocq-core.9.0.dev` (the only rocq-runtime left that allows 4.09) and then built stdlib *master* against a 9.0 parser, dying at `Logic/EqdepFacts.v:144: Syntax error: illegal begin of vernac`. Fixed by #3808, which gives `rocq-stdlib.dev` the `rocq-core >= 9.2` bound upstream already declares.

With #3808 in, no rocq-core is installable on 4.09, so this package is correctly skipped there rather than mis-built.
