### PR TITLE
rocq-runtime.9.3: require OCaml >= 4.14.0, as upstream does

### DIFF
--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.3+rc1/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.3+rc1/opam
@@ -26,7 +26,7 @@ doc: "https://rocq-prover.org/docs"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}

--- a/core-dev/packages/rocq-runtime/rocq-runtime.9.3.dev/opam
+++ b/core-dev/packages/rocq-runtime/rocq-runtime.9.3.dev/opam
@@ -26,7 +26,7 @@ doc: "https://rocq-prover.org/docs"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.21"}
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}
   "conf-linux-libc-dev" {os = "linux"}


### PR DESCRIPTION
`rocq-runtime.9.3.dev` and `rocq-runtime.9.3+rc1` both declare
`"ocaml" {>= "4.09.0"}`. Rocq 9.3 disagrees with that: its own in-tree
`rocq-runtime.opam` says `>= "4.14.0"`, and `tools/configure/configure.ml`
exits with *"You need OCaml 4.14.0 or later."*

The 9.1, 9.2 and `dev` recipes here already say `4.14.0`; only the two 9.3 ones
were missed. The value they carry is the one the 9.0 recipes use, which suggests
they were copied from that template.

**Why this matters beyond tidiness.** `scripts/opam-coq-install-remove` first
asks whether a package is installable on the job's compiler and only builds if
it is. On `opam-build:4.09.0` a package depending on `rocq-core {>= "9.0"}`
therefore splits two ways, as visible in
[job 7677268](https://gitlab.inria.fr/coq/opam-repositories/-/jobs/7677268):

- `rocq-elpi.dev` fails that check and is correctly tolerated as *"not compatible
  with the current compiler"*;
- `rocq-micromega-plugin.dev` **passes** it — possible only because
  `rocq-runtime.9.3.dev` claims 4.09 support — so CI proceeds to a real install
  that then dies:

```
[ERROR] The compilation of rocq-runtime.9.3.dev failed at
"./configure -release -prefix ... -native-compiler no".
```

That is what is currently failing `opam-build:4.09.0` on unrelated pull requests
(#3789, #3800), neither of which touches anything related.

**Scope.** Metadata only, two lines. `opam lint --warn=-21` passes on both files
under the opam 2.1.2 that `.gitlab-ci.yml` pins. Note that this makes the
`4.09.0` job *skip* rather than *pass* the affected packages: with 9.3 correctly
excluded, `rocq-core {>= "9.0"}` can still be satisfied by `rocq-core.9.0.dev`
(whose 4.09 support is genuine), so what each package does next on that job is
for CI here to answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
