### PR TITLE
coq-riscv: drop the unused coq-record-update dependency

### DIFF
--- a/released/packages/coq-riscv/coq-riscv.0.0.2/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.2/opam
@@ -13,7 +13,6 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
   "coq-coqutil" {= "0.0.2"}
-  "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"

--- a/released/packages/coq-riscv/coq-riscv.0.0.2/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.15~" & < "8.18~"}
   "coq-coqutil" {= "0.0.2"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"

--- a/released/packages/coq-riscv/coq-riscv.0.0.3/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.3/opam
@@ -13,7 +13,6 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
   "coq-coqutil" {= "0.0.2"}
-  "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"

--- a/released/packages/coq-riscv/coq-riscv.0.0.3/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.15~" & < "8.18~"}
   "coq-coqutil" {= "0.0.2"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"

--- a/released/packages/coq-riscv/coq-riscv.0.0.4/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
-  "coq" {>= "8.15~"}
+  "coq" {>= "8.15~" & < "8.19~"}
   "coq-coqutil" {>= "0.0.3" & <= "0.0.4"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"

--- a/released/packages/coq-riscv/coq-riscv.0.0.4/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.4/opam
@@ -13,7 +13,6 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
   "coq-coqutil" {>= "0.0.3" & <= "0.0.4"}
-  "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"

--- a/released/packages/coq-riscv/coq-riscv.0.0.5/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.5/opam
@@ -13,7 +13,6 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.18~"}
   "coq-coqutil" {>= "0.0.3" & <= "0.0.6"}
-  "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"

--- a/released/packages/coq-riscv/coq-riscv.0.0.5/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
-  "coq" {>= "8.18~"}
+  "coq" {>= "8.18~" & < "9.0~"}
   "coq-coqutil" {>= "0.0.3" & <= "0.0.6"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"

--- a/released/packages/coq-riscv/coq-riscv.0.0.6/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.6/opam
@@ -13,7 +13,6 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.18~"}
   "coq-coqutil" {>= "0.0.7"}
-  "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"


### PR DESCRIPTION
Removes `"coq-record-update" {>= "0.3.0"}` from all five `coq-riscv` recipes.
riscv-coq does not use it and has not since 2020.

**History.** It was a genuine direct dependency for about six weeks:
[`5cdeb48`](https://github.com/mit-plv/riscv-coq/commit/5cdeb48) (2020-10-06,
"add coq-record-update dependency") added `-Q $(DEPS_DIR)/coq-record-update/src
RecordUpdate` to the Makefile because `src/riscv/Examples/WMM.v` had
`Require Import RecordUpdate.RecordUpdate.`. `WMM.v` was deleted in
[`0b15d41`](https://github.com/mit-plv/riscv-coq/commit/0b15d41) (2020-12-04),
and Samuel Gruetter removed the now-inert Makefile flag in
[`d7a833a`](https://github.com/mit-plv/riscv-coq/commit/d7a833a) (2023-11-27,
"coq-record-update is no longer needed").

**No released tag needs it.** `v0.0.1`–`v0.0.6` all postdate the deletion of
`WMM.v`. At every tag the only textual occurrences of `RecordSet` outside
coqutil's own `RecordSetters` are the two `cbv delta [RecordSet.set]` lines in
`src/riscv/Examples/WMMFree.v`, and both sit inside the comment block spanning
lines 844–1141 of that file. Independently of that, all five recipes build with
`EXTERNAL_DEPENDENCIES=1`, which drops the in-tree `-Q` flags entirely, so the
flag was inert for these recipes even before `d7a833a`.

**Verification.** Built riscv-coq master (97 `.v` files, `make -j8
EXTERNAL_DEPENDENCIES=1 all`) in a switch that has `coq-coqutil` installed and
`coq-record-update` absent from `user-contrib` entirely: 97/97 `.vo`, no errors,
`WMMFree.vo` included. `opam lint` passes on all five files under the opam 2.1.2
that `.gitlab-ci.yml` pins. I did not run `opam install` for each released
version locally, so CI is the first test of that path.

Companion change upstream: mit-plv/riscv-coq#50 drops the same line from the
in-tree `coq-riscv.opam` it adds. (`.travis.yml` still clones
`tchajed/coq-record-update`; that is dead config, left alone here.)


---

### Second commit: `coq` upper bounds (this is what was making CI red)

The first CI run failed on `coq-riscv.0.0.2`/`0.0.3`/`0.0.4`/`0.0.5`, and not
because of `coq-record-update`: those four recipes declare only a lower bound on
`coq`, so the solver picks the newest Rocq (9.1.1) and then tries to build the
2022–2024 `coqutil` release each of them pins. That is pre-existing master
breakage which this PR merely exposed, since the archive's CI builds only the
files a PR touches. `coq-riscv.0.0.6` was unaffected and installed fine — it
requires `coq-coqutil >= 0.0.7`.

Three distinct breakages, one per coqutil generation:

* **coqutil ≤ 0.0.4** call Ltac2 `List.fold_left`/`fold_right` with the pre-8.19
  argument order (changed by coq/coq#18197, first released in 8.19+rc1):
  `Error: This expression has type message list but an expression was expected of type message`.
  coqutil 0.0.5 added its own compat shim (`src/coqutil/Ltac2Lib/List.v`), so
  0.0.5 and 0.0.6 are fine here.
* **coqutil 0.0.2** additionally uses `Zdiv.div_Zdiv`, dropped in 8.18+rc1:
  `Error: The reference Zdiv.div_Zdiv was not found in the current environment.`
* **coqutil 0.0.6** asserts the fully qualified name `"Coq.Init.Datatypes.unit"`
  in `src/coqutil/Macros/WithQualName.v:33`; under Rocq 9 that path root is
  `Corelib`, hence
  `Unable to unify "[("Corelib.Init.Datatypes.unit", unit); …]" with "[("Coq.Init.Datatypes.unit", unit); …]"`.
  coqutil 0.0.7 works around it in `src/coqutil/Tactics/reference_to_string.v`.

So each recipe now bounds `coq` by what its dependency closure can actually build:

| coq-riscv | coq-coqutil | `coq` bound |
| --- | --- | --- |
| 0.0.2, 0.0.3 | `= 0.0.2` | `>= "8.15~" & < "8.18~"` |
| 0.0.4 | `>= 0.0.3 & <= 0.0.4` | `>= "8.15~" & < "8.19~"` |
| 0.0.5 | `>= 0.0.3 & <= 0.0.6` | `>= "8.18~" & < "9.0~"` |
| 0.0.6 | `>= 0.0.7` | unchanged |

**Verification.** I reproduced the CI build step locally — opam 2.1.2, sandboxed
throwaway opam root, the local `released/` directory as a repository,
`opam install coq-riscv.<v> -y --with-test` — on both compilers CI uses. All
eight combinations install:

| | 0.0.2 | 0.0.3 | 0.0.4 | 0.0.5 |
| --- | --- | --- | --- | --- |
| ocaml 4.14.2 | ✅ coq 8.16.1 | ✅ coq 8.16.1 | ✅ coq 8.16.1 | ✅ coq 8.20.1 |
| ocaml 5.3.0 | ✅ coq 8.17.1 | ✅ coq 8.17.1 | ✅ coq 8.18.0 | ✅ coq 8.20.1 |

`opam lint --warn=-21 --check-upstream` passes on all five recipes under opam
2.1.2 (the version `.gitlab-ci.yml` pins).

**Not fixed here.** The overclaim really lives in the `coq-coqutil` recipes:
`coq-coqutil.0.0.1`–`0.0.6` declare no upper bound on `coq` at all, so every
other consumer (`coq-bedrock2`, `coq-bedrock2-compiler`, `coq-kami`, …) has the
same latent problem. Bounding them there would be the more complete fix, but it
would pull six more legacy recipes into this PR's CI scope, each needing its own
full Coq build. Happy to send that as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
