### PR TITLE
release MathComp-Analysis 1.17.0

### DIFF
--- a/released/packages/rocq-mathcomp-analysis-stdlib/rocq-mathcomp-analysis-stdlib.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-analysis-stdlib/rocq-mathcomp-analysis-stdlib.1.17.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "analysis_stdlib" "-j%{jobs}%"]
+install: [make "-C" "analysis_stdlib" "install"]
+depends: [
+  "rocq-mathcomp-analysis" { = version}
+  "rocq-mathcomp-reals-stdlib"
+]
+
+conflicts: [ "coq-mathcomp-analysis-stdlib" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}

--- a/released/packages/rocq-mathcomp-analysis/rocq-mathcomp-analysis.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-analysis/rocq-mathcomp-analysis.1.17.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This package contains a library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "theories" "-j%{jobs}%"]
+install: [make "-C" "theories" "install"]
+depends: [
+  "rocq-mathcomp-reals" { = version}
+  "rocq-mathcomp-solvable"
+  "rocq-mathcomp-field"
+  "rocq-mathcomp-bigenough" { (>= "1.0.0") }
+  "rocq-navi" {= "0.5.1" & with-doc}
+]
+
+conflicts: [ "coq-mathcomp-analysis" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:analysis"
+  "keyword:Cantor"
+  "keyword:topology"
+  "keyword:real numbers"
+  "keyword:sequence"
+  "keyword:convexity"
+  "keyword:Landau notation"
+  "keyword:logarithm"
+  "keyword:sin"
+  "keyword:cos"
+  "keyword:tangent"
+  "keyword:trigonometric function"
+  "keyword:exponential"
+  "keyword:differentiation"
+  "keyword:derivative"
+  "keyword:measure theory"
+  "keyword:integration"
+  "keyword:Lebesgue"
+  "keyword:probability"
+  "logpath:mathcomp.analysis"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}

--- a/released/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-classical/rocq-mathcomp-classical.1.17.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for classical logic for mathematical components"
+description: """
+This repository contains a library for classical logic for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "classical" "-j%{jobs}%"]
+install: [make "-C" "classical" "install"]
+depends: [
+  "rocq-core" { (>= "9.0" & < "9.4~") | (= "dev") }
+  "rocq-mathcomp-algebra" { (>= "2.6.0" & < "2.7~") }
+  "rocq-mathcomp-finmap"
+  "rocq-hierarchy-builder" { (>= "1.8.0") }
+]
+
+conflicts: [ "coq-mathcomp-classical" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Logic/Classical logic"
+  "keyword:classical logic"
+  "keyword:logic"
+  "keyword:sets"
+  "keyword:set theory"
+  "keyword:function"
+  "keyword:cardinal"
+  "keyword:filter"
+  "logpath:mathcomp.classical"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}

--- a/released/packages/rocq-mathcomp-experimental-reals/rocq-mathcomp-experimental-reals.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-experimental-reals/rocq-mathcomp-experimental-reals.1.17.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for alternative real numbers for mathematical components"
+description: """
+This package contains an experiment along real numbers
+made at the beginning of the MathComp-Analysis library
+(which now offers the coq-mathcomp-reals package).
+
+Beware that this still contains a few Admitted."""
+
+build: [make "-C" "experimental_reals" "-j%{jobs}%"]
+install: [make "-C" "experimental_reals" "install"]
+depends: [
+  "rocq-mathcomp-analysis" { = version}
+  "rocq-mathcomp-bigenough" { (>= "1.0.0") }
+]
+
+conflicts: [ "coq-mathcomp-experimental-reals" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.experimental_reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}

--- a/released/packages/rocq-mathcomp-reals-stdlib/rocq-mathcomp-reals-stdlib.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-reals-stdlib/rocq-mathcomp-reals-stdlib.1.17.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library to link real numbers from mathematical components and Stdlib"
+description: """
+This package contains a library to link real numbers for
+the Coq proof-assistant using the Mathematical Components library and Stdlib."""
+
+build: [make "-C" "reals_stdlib" "-j%{jobs}%"]
+install: [make "-C" "reals_stdlib" "install"]
+depends: [
+  ("coq" {< "8.21~"}
+  | "rocq-stdlib" { (>= "9.0" & < "9.1~") | (= "dev") })
+  "rocq-mathcomp-reals" { = version}
+]
+
+conflicts: [ "coq-mathcomp-reals-stdlib" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "logpath:mathcomp.reals_stdlib"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}

--- a/released/packages/rocq-mathcomp-reals/rocq-mathcomp-reals.1.17.0/opam
+++ b/released/packages/rocq-mathcomp-reals/rocq-mathcomp-reals.1.17.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "A library for real numbers for mathematical components"
+description: """
+This package contains a library for real numbers for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-C" "reals" "-j%{jobs}%"]
+install: [make "-C" "reals" "install"]
+depends: [
+  "rocq-mathcomp-classical" { = version}
+]
+
+conflicts: [ "coq-mathcomp-reals" { < "1.16~" } ]
+
+tags: [
+  "category:Mathematics/Real Numbers"
+  "keyword:real numbers"
+  "keyword:reals"
+  "keyword:extended real numbers"
+  "logpath:mathcomp.reals"
+]
+authors: [
+  "Reynald Affeldt"
+  "Alessandro Bruni"
+  "Yves Bertot"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Pierre Roux"
+  "Kazuhiko Sakaguchi"
+  "Zachary Stone"
+  "Pierre-Yves Strub"
+  "Laurent Théry"
+]
+
+url {
+src: "https://github.com/math-comp/analysis/releases/download/1.17.0/analysis-1.17.0.tar.gz"
+checksum: "sha256=13e6bfd2a84d6a30fa54e99fdb3d7db03e2db2ac32a1e64db7f3ef6b4351fca0"
+}


### PR DESCRIPTION
ci-skip: coq-mathcomp-classical coq-mathcomp-reals coq-mathcomp-analysis coq-mathcomp-reals-stdlib