### PR TITLE
extra-dev: coq-prosa compatibility shim for rocq-prosa

### DIFF
--- a/extra-dev/packages/coq-prosa/coq-prosa.dev/opam
+++ b/extra-dev/packages/coq-prosa/coq-prosa.dev/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Björn Brandenburg <bbb@mpi-sws.org>"
+authors: [
+  "Felipe Cerqueira"
+  "Sergey Bozhko"
+  "Björn Brandenburg"
+  "Pierre Roux"
+  "Kimaya Bedarkar"
+  "Marco Maida"
+  "Athul Raj Kollareth"
+  "Sophie Quinton"
+  "Maxime Lesourd"
+]
+license: "BSD-2-Clause"
+homepage: "https://prosa.mpi-sws.org/"
+doc: "https://prosa.mpi-sws.org/releases/v0.6/spec/with-proofs/toc.html"
+bug-reports: "https://gitlab.mpi-sws.org/RT-PROOFS/rt-proofs/issues"
+dev-repo: "git+https://gitlab.mpi-sws.org/RT-PROOFS/rt-proofs.git"
+
+depends: [
+  "rocq-prosa" {= version}
+]
+
+synopsis: "Compatibility package for rocq-prosa"
+description: """
+This package installs no files of its own. It exists so that packages and
+users still asking for coq-prosa get rocq-prosa, which is where the library
+now lives."""


### PR DESCRIPTION
Split out of #3821, which adds the same shim for four other packages. Opened as a
draft because **this row is expected to be red, and not because of the shim.**

`coq-prosa` has no `.dev` row while its twin `rocq-prosa` does, and both install to
`logpath:prosa`. So on a dev switch there is nothing at the `coq-prosa` name that
resolves without overwriting the twin's files. This adds a `coq-prosa.dev` that
installs no files of its own and only depends on `rocq-prosa {= version}` — the same
shape as the 14 `coq-*`/`rocq-*` pairs already in `extra-dev` that are wrapped this
way (`coq-mathcomp-*`, `coq-equations`, `coq-elpi`, `coq-hierarchy-builder`, ...).

## Why it is red

The pre-existing `rocq-prosa.dev` does not build against the dev prover. CI builds a
changed package's dependencies, so adding a dependency on it is enough to surface the
failure. Both legs of #3821 (4.14.2 and 5.3.0) resolved `rocq-prosa` at `dev` and died
inside its own sources:

```
[ERROR] The compilation of rocq-prosa.dev failed at "make -j2".
File "./util/tactics.v", line 125, characters 21-35:
Error: The reference ssreflect.done was not found in the current environment.
Did you mean ssreflect.hide, ssreflect.phant, ssreflect.hideT or ssreflect.Phant?
make[2]: *** [Makefile.coq:868: util/tactics.vo] Error 1
```

Nothing in this PR touches `rocq-prosa.dev`; the diff is one new file. The shim will
go green as soon as `rocq-prosa` builds at dev, at which point this can be undrafted
and merged as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
