### PR TITLE
extra-dev: exclude the mismatched coq-* wrapper from 27 rocq-*.dev rows

### DIFF
--- a/extra-dev/packages/rocq-bignums/rocq-bignums.dev/opam
+++ b/extra-dev/packages/rocq-bignums/rocq-bignums.dev/opam
@@ -21,6 +21,7 @@ depends: [
   "rocq-core" {= "dev"}
   "rocq-stdlib"
 ]
+conflicts: [ "coq-bignums" { != version } ]
 
 tags: [
   "category:Miscellaneous/Coq Extensions"

--- a/extra-dev/packages/rocq-elpi/rocq-elpi.dev/opam
+++ b/extra-dev/packages/rocq-elpi/rocq-elpi.dev/opam
@@ -24,6 +24,7 @@ depends: [
   "odoc" {with-doc}
   "rocq-stdlib" {with-doc}
 ]
+conflicts: [ "coq-elpi" { != version } ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/extra-dev/packages/rocq-equations/rocq-equations.dev/opam
+++ b/extra-dev/packages/rocq-equations/rocq-equations.dev/opam
@@ -26,6 +26,7 @@ depends: [
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]
+conflicts: [ "coq-equations" { != version } ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/extra-dev/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-algebra/rocq-mathcomp-algebra.dev/opam
@@ -14,6 +14,7 @@ depends: [
   "rocq-mathcomp-finite-group" { = version }
   "rocq-micromega-plugin" { >= "1.0.0" }
 ]
+conflicts: [ "coq-mathcomp-algebra" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-boot/rocq-mathcomp-boot.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-boot/rocq-mathcomp-boot.dev/opam
@@ -16,6 +16,7 @@ depends: [
   "elpi" {>= "1.17.0"}
   "rocq-hierarchy-builder" {>= "1.9.0"}
 ]
+conflicts: [ "coq-mathcomp-boot" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-field/rocq-mathcomp-field.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-field/rocq-mathcomp-field.dev/opam
@@ -10,6 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "field" "-j" "%{jobs}%" ]
 install: [ make "-C" "field" "install" ]
 depends: [ "rocq-mathcomp-solvable" { = version } ]
+conflicts: [ "coq-mathcomp-field" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-finite-group/rocq-mathcomp-finite-group.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-finite-group/rocq-mathcomp-finite-group.dev/opam
@@ -10,6 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "finite_group" "-j" "%{jobs}%" ]
 install: [ make "-C" "finite_group" "install" ]
 depends: [ "rocq-mathcomp-boot" { = version } ]
+conflicts: [ "coq-mathcomp-fingroup" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-group-representation/rocq-mathcomp-group-representation.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-group-representation/rocq-mathcomp-group-representation.dev/opam
@@ -10,6 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "group_representation" "-j" "%{jobs}%" ]
 install: [ make "-C" "group_representation" "install" ]
 depends: [ "rocq-mathcomp-field" { = version } ]
+conflicts: [ "coq-mathcomp-character" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-order/rocq-mathcomp-order.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-order/rocq-mathcomp-order.dev/opam
@@ -10,6 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "order" "-j" "%{jobs}%" ]
 install: [ make "-C" "order" "install" ]
 depends: [ "rocq-mathcomp-boot" { = version } ]
+conflicts: [ "coq-mathcomp-order" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-solvable/rocq-mathcomp-solvable.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-solvable/rocq-mathcomp-solvable.dev/opam
@@ -10,6 +10,7 @@ license: "CECILL-B"
 build: [ make "-C" "solvable" "-j" "%{jobs}%" ]
 install: [ make "-C" "solvable"  "install" ]
 depends: [ "rocq-mathcomp-algebra" { = version } ]
+conflicts: [ "coq-mathcomp-solvable" { != version } ]
 
 tags: [
   "keyword:small scale reflection"

--- a/extra-dev/packages/rocq-mathcomp-ssreflect/rocq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/rocq-mathcomp-ssreflect/rocq-mathcomp-ssreflect.dev/opam
@@ -13,6 +13,7 @@ depends: [
   "rocq-mathcomp-boot" { = version }
   "rocq-mathcomp-order" { = version }
 ]
+conflicts: [ "coq-mathcomp-ssreflect" { != version } ]
 
 authors: [ "The Mathematical Components team" ]
 

--- a/extra-dev/packages/rocq-metarocq-common/rocq-metarocq-common.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-common/rocq-metarocq-common.dev/opam
@@ -29,6 +29,7 @@ install: [
 depends: [
   "rocq-metarocq-utils" {= version}
 ]
+conflicts: [ "coq-metacoq-common" { != version } ]
 synopsis: "The common library of Template Rocq and PCUIC"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-erasure-plugin/rocq-metarocq-erasure-plugin.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-erasure-plugin/rocq-metarocq-erasure-plugin.dev/opam
@@ -30,6 +30,7 @@ depends: [
   "rocq-metarocq-template-pcuic" {= version}
   "rocq-metarocq-erasure" {= version}
 ]
+conflicts: [ "coq-metacoq-erasure-plugin" { != version } ]
 synopsis: "Implementation and verification of an erasure procedure for Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-erasure/rocq-metarocq-erasure.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-erasure/rocq-metarocq-erasure.dev/opam
@@ -30,6 +30,7 @@ depends: [
   "rocq-metarocq-safechecker" {= version}
   "rocq-metarocq-template-pcuic" {= version}
 ]
+conflicts: [ "coq-metacoq-erasure" { != version } ]
 synopsis: "Implementation and verification of an erasure procedure for Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-pcuic/rocq-metarocq-pcuic.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-pcuic/rocq-metarocq-pcuic.dev/opam
@@ -29,6 +29,7 @@ install: [
 depends: [
   "rocq-metarocq-common" {= version}
 ]
+conflicts: [ "coq-metacoq-pcuic" { != version } ]
 synopsis: "A type system equivalent to Rocq's and its metatheory"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-quotation/rocq-metarocq-quotation.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-quotation/rocq-metarocq-quotation.dev/opam
@@ -31,6 +31,7 @@ depends: [
   "rocq-metarocq-pcuic" {= version}
   "rocq-metarocq-template-pcuic" {= version}
 ]
+conflicts: [ "coq-metacoq-quotation" { != version } ]
 synopsis: "Gallina quotation functions for Template Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-safechecker-plugin/rocq-metarocq-safechecker-plugin.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-safechecker-plugin/rocq-metarocq-safechecker-plugin.dev/opam
@@ -30,6 +30,7 @@ depends: [
   "rocq-metarocq-template-pcuic" {= version}
   "rocq-metarocq-safechecker" {= version}
 ]
+conflicts: [ "coq-metacoq-safechecker-plugin" { != version } ]
 synopsis: "Implementation and verification of an erasure procedure for Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-safechecker/rocq-metarocq-safechecker.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-safechecker/rocq-metarocq-safechecker.dev/opam
@@ -29,6 +29,7 @@ install: [
 depends: [
   "rocq-metarocq-pcuic" {= version}
 ]
+conflicts: [ "coq-metacoq-safechecker" { != version } ]
 synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-template-pcuic/rocq-metarocq-template-pcuic.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-template-pcuic/rocq-metarocq-template-pcuic.dev/opam
@@ -30,6 +30,7 @@ depends: [
   "rocq-metarocq-template" {= version}
   "rocq-metarocq-pcuic" {= version}
 ]
+conflicts: [ "coq-metacoq-template-pcuic" { != version } ]
 synopsis: "Translations between Template Rocq and PCUIC and proofs of correctness"
 description: """
 """

--- a/extra-dev/packages/rocq-metarocq-template/rocq-metarocq-template.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-template/rocq-metarocq-template.dev/opam
@@ -29,6 +29,7 @@ install: [
 depends: [
   "rocq-metarocq-common" {= version}
 ]
+conflicts: [ "coq-metacoq-template" { != version } ]
 synopsis: "A quoting and unquoting library for Rocq in Rocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-translations/rocq-metarocq-translations.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-translations/rocq-metarocq-translations.dev/opam
@@ -29,6 +29,7 @@ install: [
 depends: [
   "rocq-metarocq-template" {= version}
 ]
+conflicts: [ "coq-metacoq-translations" { != version } ]
 synopsis: "Translations built on top of MetaRocq"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq-utils/rocq-metarocq-utils.dev/opam
+++ b/extra-dev/packages/rocq-metarocq-utils/rocq-metarocq-utils.dev/opam
@@ -33,6 +33,7 @@ depends: [
   "rocq-equations" { = "dev" }
   "coq-ext-lib" { = "dev" }
 ]
+conflicts: [ "coq-metacoq-utils" { != version } ]
 synopsis: "The utility library of Template Rocq and PCUIC"
 description: """
 MetaRocq is a meta-programming framework for Rocq.

--- a/extra-dev/packages/rocq-metarocq/rocq-metarocq.dev/opam
+++ b/extra-dev/packages/rocq-metarocq/rocq-metarocq.dev/opam
@@ -25,6 +25,7 @@ depends: [
   "rocq-metarocq-translations" {= version}
   "rocq-metarocq-quotation" {= version}
 ]
+conflicts: [ "coq-metacoq" { != version } ]
 build: [
   ["bash" "./configure.sh" ] {with-test}
   [make "-C" "examples" ] {with-test}

--- a/extra-dev/packages/rocq-parseque/rocq-parseque.dev/opam
+++ b/extra-dev/packages/rocq-parseque/rocq-parseque.dev/opam
@@ -17,6 +17,7 @@ depends: [
   "rocq-core"
   "rocq-stdlib"
 ]
+conflicts: [ "coq-parseque" { != version } ]
 
 tags: [
   "category:Computer Science/Data Types and Data Structures"

--- a/extra-dev/packages/rocq-prosa/rocq-prosa.dev/opam
+++ b/extra-dev/packages/rocq-prosa/rocq-prosa.dev/opam
@@ -26,6 +26,7 @@ depends: [
   "coq-mathcomp-algebra" {>= "2.4"}
   "coq-mathcomp-zify" {>= "1.5.0"}
 ]
+conflicts: [ "coq-prosa" { != version } ]
 
 tags: [
   "keyword:prosa"

--- a/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
+++ b/extra-dev/packages/rocq-sail-stdpp/rocq-sail-stdpp.dev/opam
@@ -39,6 +39,7 @@ depends: [
   "rocq-stdpp-bitvector" {>= "1.13.0"}
   "odoc" {with-doc}
 ]
+conflicts: [ "coq-sail-stdpp" { != version } ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/extra-dev/packages/rocq-trakt/rocq-trakt.dev/opam
+++ b/extra-dev/packages/rocq-trakt/rocq-trakt.dev/opam
@@ -15,6 +15,7 @@ depends: [
   "rocq-elpi" {>= "3.2.0"}
   "odoc" {with-doc}
 ]
+conflicts: [ "coq-trakt" { != version } ]
 # About the version of dune:
 # - rocq-elpi : (using coq 0.8) ; coq 0.8 exists until dune 3.23
 # - rocq-trakt : (using rocq 0.11) ; rocq 0.11 exists since dune 3.21


### PR DESCRIPTION
Twenty-seven `rocq-*.dev` rows have a `coq-*.dev` compatibility wrapper but do not exclude that wrapper at any other version. This adds `conflicts: [ "coq-X" { != version } ]` to each of them.

### Why

A `coq-X` wrapper ties itself to its `rocq-*` twin with `depends: [ "rocq-Y" {= version} ]` and installs nothing of its own. `conflicts: [ "coq-X" { != version } ]` is the exact complement of that tie, so the only admissible pairing left is wrapper-with-twin. Without it the solver can pick `rocq-Y.dev` together with an *older, real* `coq-X` — one that ships its own files at the same install paths — and the two clobber each other.

Six rows in the archive already do exactly this, and this PR just extends the convention to the rest: `rocq-aac-tactics.dev`, `rocq-libhyps.dev`, `rocq-mathcomp-bigenough.dev`, `rocq-mathcomp-finmap.dev`, `rocq-mathcomp-real-closed.dev`, `rocq-relation-algebra.dev`.

### Rows

| edited row | excludes |
| --- | --- |
| `rocq-bignums.dev` | `coq-bignums` |
| `rocq-elpi.dev` | `coq-elpi` |
| `rocq-equations.dev` | `coq-equations` |
| `rocq-mathcomp-algebra.dev` | `coq-mathcomp-algebra` |
| `rocq-mathcomp-boot.dev` | `coq-mathcomp-boot` |
| `rocq-mathcomp-field.dev` | `coq-mathcomp-field` |
| `rocq-mathcomp-finite-group.dev` | `coq-mathcomp-fingroup` |
| `rocq-mathcomp-group-representation.dev` | `coq-mathcomp-character` |
| `rocq-mathcomp-order.dev` | `coq-mathcomp-order` |
| `rocq-mathcomp-solvable.dev` | `coq-mathcomp-solvable` |
| `rocq-mathcomp-ssreflect.dev` | `coq-mathcomp-ssreflect` |
| `rocq-metarocq.dev` | `coq-metacoq` |
| `rocq-metarocq-common.dev` | `coq-metacoq-common` |
| `rocq-metarocq-erasure.dev` | `coq-metacoq-erasure` |
| `rocq-metarocq-erasure-plugin.dev` | `coq-metacoq-erasure-plugin` |
| `rocq-metarocq-pcuic.dev` | `coq-metacoq-pcuic` |
| `rocq-metarocq-quotation.dev` | `coq-metacoq-quotation` |
| `rocq-metarocq-safechecker.dev` | `coq-metacoq-safechecker` |
| `rocq-metarocq-safechecker-plugin.dev` | `coq-metacoq-safechecker-plugin` |
| `rocq-metarocq-template.dev` | `coq-metacoq-template` |
| `rocq-metarocq-template-pcuic.dev` | `coq-metacoq-template-pcuic` |
| `rocq-metarocq-translations.dev` | `coq-metacoq-translations` |
| `rocq-metarocq-utils.dev` | `coq-metacoq-utils` |
| `rocq-parseque.dev` | `coq-parseque` |
| `rocq-prosa.dev` | `coq-prosa` |
| `rocq-sail-stdpp.dev` | `coq-sail-stdpp` |
| `rocq-trakt.dev` | `coq-trakt` |

Five of the pairs are renamed rather than a plain `coq-`/`rocq-` prefix swap, which is why the census was keyed on what each wrapper's `depends:` actually names rather than on the package name: `coq-mathcomp-fingroup` → `rocq-mathcomp-finite-group`, `coq-mathcomp-character` → `rocq-mathcomp-group-representation`, and the twelve `coq-metacoq*` → `rocq-metarocq*` rows.

### How the set was chosen

A `coq-X.dev` counts as a wrapper only if it has **no `build:` field and no `install:` field** — with neither, opam installs nothing at all — and its `depends:` names exactly one `rocq-*` package. Rows that merely depend on the prover are excluded by that test, since they all build something of their own: `coq-hott`, `coq-dpdgraph`, `coq-fourcolor-reals`, `coq-mathcomp-tarjan`, `coq-record-update`, and the two core-dev hybrids `coq-core.dev` / `coq-stdlib.dev`, which depend `{= version}` on their rocq twin but also run their own `dune build`. Nothing under `core-dev/` is touched.

`rocq-lean-import.dev` is left alone: it uses `conflict-class`, which is strictly stronger.

### Checks

- `opam lint --short` on all 27 edited files: no failures, no notes.
- Re-running the census over the edited tree reports zero remaining rows.
- Diff is 27 files, 27 insertions, no deletions.

### One note for maintainers

`extra-dev/packages/rocq-elpi/rocq-elpi.dev/opam` is the only file here carrying `# This file is generated by dune, edit dune-project instead`. The edit is correct in the archive as it stands, but a regeneration from upstream `dune-project` would drop it unless the field is mirrored there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L9BGQT7XUuubV6C619DW4b
