### PR TITLE
Renaming: coqide-server.dev -> rocqide-server.dev

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -10,6 +10,6 @@ depends: [
   "dune" {>= "3.8"}
   "coq-core" {= version}
   "coq-stdlib"
-  "coqide-server" {= version}
+  "rocqide-server" {= version}
 ]
 dev-repo: "git+https://github.com/rocq-prover/rocq.git"

--- a/core-dev/packages/rocqide-server/rocqide-server.dev/opam
+++ b/core-dev/packages/rocqide-server/rocqide-server.dev/opam
@@ -13,9 +13,9 @@ structured way."""
 maintainer: ["The Rocq development team <coqdev@inria.fr>"]
 authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
 license: "LGPL-2.1-only"
-homepage: "https://coq.inria.fr/"
-doc: "https://coq.github.io/doc/"
-bug-reports: "https://github.com/coq/coq/issues"
+homepage: "https://rocq-prover.org/"
+doc: "https://rocq-prover.org/docs/"
+bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "dune" {>= "3.8"}
   "rocq-runtime" {= version}
@@ -35,8 +35,8 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/coq/coq.git"
+dev-repo: "git+https://github.com/rocq-prover/rocq.git"
 
 url {
-  src: "git+https://github.com/coq/coq.git#master"
+  src: "git+https://github.com/rocq-prover/rocq.git#master"
 }


### PR DESCRIPTION
after https://github.com/rocq-prover/rocq/pull/22327